### PR TITLE
fix(omdb): stop partial OMDb responses from wiping stored IMDb/RT ratings

### DIFF
--- a/src/Service/Omdb/OmdbMovieRatingSync.php
+++ b/src/Service/Omdb/OmdbMovieRatingSync.php
@@ -41,14 +41,20 @@ class OmdbMovieRatingSync
             return;
         }
 
+        // OMDb regularly answers with HTTP 200 but omits ratings for a movie
+        // (imdbRating "N/A", or no Rotten Tomatoes entry). Fall back to the
+        // stored value for every field OMDb did not return, so a partial or
+        // empty response can never wipe a previously synced rating.
+        $mergedRatings = $this->mergeWithExistingRatings($movie, $omdbRatings);
+
         // Check if ratings have changed
-        $hasChanged = $this->hasRatingsChanged($movie, $omdbRatings);
+        $hasChanged = $this->hasRatingsChanged($movie, $mergedRatings);
         if ($hasChanged === false) {
             $this->logger->debug('OMDb: Skipped updating unchanged movie ratings', [$this->generateMovieLogData($movie)]);
             return;
         }
 
-        $this->movieRepository->updateOmdbRatings($movieId, $omdbRatings);
+        $this->movieRepository->updateOmdbRatings($movieId, $mergedRatings);
 
         $this->logger->info('OMDb: Updated movie ratings', [
             array_merge(
@@ -57,13 +63,28 @@ class OmdbMovieRatingSync
                     'oldImdbRating' => $movie->getImdbRatingAverage(),
                     'oldImdbVotes' => $movie->getImdbVoteCount(),
                     'oldRtRating' => $movie->getRtRatingAverage(),
-                    'newImdbRating' => $omdbRatings->getImdbRating(),
-                    'newImdbVotes' => $omdbRatings->getImdbVotes(),
-                    'newRtRating' => $omdbRatings->getRottenTomatoesRating(),
-                    'metacritic' => $omdbRatings->getMetacriticRating(),
+                    'newImdbRating' => $mergedRatings->getImdbRating(),
+                    'newImdbVotes' => $mergedRatings->getImdbVotes(),
+                    'newRtRating' => $mergedRatings->getRottenTomatoesRating(),
+                    'metacritic' => $mergedRatings->getMetacriticRating(),
                 ],
             )
         ]);
+    }
+
+    /**
+     * Merge a freshly fetched OMDb result with the values already stored on the
+     * movie. Any rating OMDb did not return (null) keeps its stored value, which
+     * prevents a partial or empty OMDb response from overwriting good data with null.
+     */
+    private function mergeWithExistingRatings(MovieEntity $movie, OmdbRatings $freshRatings) : OmdbRatings
+    {
+        return OmdbRatings::create(
+            $freshRatings->getImdbRating() ?? $movie->getImdbRatingAverage(),
+            $freshRatings->getImdbVotes() ?? $movie->getImdbVoteCount(),
+            $freshRatings->getRottenTomatoesRating() ?? $movie->getRtRatingAverage(),
+            $freshRatings->getMetacriticRating(),
+        );
     }
 
     public function syncMultipleMovieRatings(

--- a/tests/unit/Service/Omdb/OmdbMovieRatingSyncTest.php
+++ b/tests/unit/Service/Omdb/OmdbMovieRatingSyncTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Movary\Service\Omdb;
+
+use Movary\Api\Omdb\OmdbApi;
+use Movary\Domain\Movie\MovieApi;
+use Movary\Domain\Movie\MovieEntity;
+use Movary\Domain\Movie\MovieRepository;
+use Movary\Service\Omdb\OmdbMovieRatingSync;
+use Movary\ValueObject\OmdbRatings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(OmdbMovieRatingSync::class)]
+class OmdbMovieRatingSyncTest extends TestCase
+{
+    private OmdbApi&MockObject $omdbApi;
+
+    private MovieApi&MockObject $movieApi;
+
+    private MovieRepository&MockObject $movieRepository;
+
+    private OmdbMovieRatingSync $subject;
+
+    protected function setUp() : void
+    {
+        $this->omdbApi = $this->createMock(OmdbApi::class);
+        $this->movieApi = $this->createMock(MovieApi::class);
+        $this->movieRepository = $this->createMock(MovieRepository::class);
+
+        $this->subject = new OmdbMovieRatingSync(
+            $this->omdbApi,
+            $this->movieApi,
+            $this->movieRepository,
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testEmptyOmdbResponseDoesNotWipeStoredRatings() : void
+    {
+        $this->movieApi->method('findById')->willReturn($this->createMovieWithRatings(9.3, 2000000, 89));
+
+        // OMDb answered with HTTP 200 but returned no ratings at all.
+        $this->omdbApi->method('fetchMovieRatings')->willReturn(OmdbRatings::create(null, null, null, null));
+
+        // The stored ratings must be kept, so no destructive update is written.
+        $this->movieRepository->expects(self::never())->method('updateOmdbRatings');
+
+        $this->subject->syncMovieRating(1);
+    }
+
+    public function testPartialOmdbResponseKeepsMissingRottenTomatoesRating() : void
+    {
+        $this->movieApi->method('findById')->willReturn($this->createMovieWithRatings(9.3, 2000000, 89));
+
+        // OMDb returned an updated IMDb rating but omitted the Rotten Tomatoes entry.
+        $this->omdbApi->method('fetchMovieRatings')->willReturn(OmdbRatings::create(9.5, 2100000, null, null));
+
+        $this->movieRepository->expects(self::once())
+            ->method('updateOmdbRatings')
+            ->with(
+                1,
+                self::callback(
+                    static fn (OmdbRatings $ratings) : bool => $ratings->getImdbRating() === 9.5
+                        && $ratings->getImdbVotes() === 2100000
+                        && $ratings->getRottenTomatoesRating() === 89, // preserved, not wiped
+                ),
+            );
+
+        $this->subject->syncMovieRating(1);
+    }
+
+    public function testFullOmdbResponseUpdatesAllRatings() : void
+    {
+        $this->movieApi->method('findById')->willReturn($this->createMovieWithRatings(9.3, 2000000, 89));
+
+        $this->omdbApi->method('fetchMovieRatings')->willReturn(OmdbRatings::create(9.5, 2100000, 95, 82));
+
+        $this->movieRepository->expects(self::once())
+            ->method('updateOmdbRatings')
+            ->with(
+                1,
+                self::callback(
+                    static fn (OmdbRatings $ratings) : bool => $ratings->getImdbRating() === 9.5
+                        && $ratings->getRottenTomatoesRating() === 95,
+                ),
+            );
+
+        $this->subject->syncMovieRating(1);
+    }
+
+    private function createMovieWithRatings(?float $imdbRating, ?int $imdbVotes, ?int $rtRating) : MovieEntity
+    {
+        return MovieEntity::createFromArray([
+            'id' => 1,
+            'title' => 'The Shawshank Redemption',
+            'trakt_id' => null,
+            'imdb_id' => 'tt0111161',
+            'tmdb_id' => 278,
+            'poster_path' => null,
+            'overview' => null,
+            'tagline' => null,
+            'original_language' => null,
+            'runtime' => null,
+            'release_date' => null,
+            'tmdb_vote_average' => null,
+            'tmdb_vote_count' => null,
+            'tmdb_poster_path' => null,
+            'imdb_rating_average' => $imdbRating,
+            'imdb_rating_vote_count' => $imdbVotes,
+            'rt_rating_average' => $rtRating,
+            'rt_rating_vote_count' => $rtRating === null ? null : 1,
+            'updated_at_tmdb' => null,
+            'updated_at_imdb' => null,
+            'updated_at_omdb' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
Behebt den bestaetigten Bug, dass IMDB/RT-Ratings nach ein paar Stunden wieder verschwinden.

## Root Cause
`OmdbMovieRatingSync::syncMovieRating` reicht das gefetchte `OmdbRatings` direkt an `MovieRepository::updateOmdbRatings`, das alle vier Rating-Spalten **bedingungslos** schreibt. OMDb liefert regelmaessig HTTP 200 **ohne** Ratings (`imdbRating: "N/A"` oder kein Rotten-Tomatoes-Eintrag) -> nicht-null `OmdbRatings` mit null-Feldern. `hasRatingsChanged` wertet `null != 9.3` als "geaendert" -> gute DB-Werte werden mit `NULL` ueberschrieben.

## Fix
Neue `mergeWithExistingRatings()`: jedes Feld, das OMDb nicht liefert, faellt auf den gespeicherten Wert zurueck. Partielle Antwort aktualisiert nur, was OMDb liefert; leere Antwort -> kein Update. Ein bekanntes Rating wird nie auf null zurueckgestuft.

## Beweis
Regressionstest `tests/unit/Service/Omdb/OmdbMovieRatingSyncTest.php` (empty -> kein Wipe, partial -> RT erhalten, full -> Update). Faellt gegen den alten Code (zeigt `rottenTomatoesRating => null`), besteht mit Fix. 3 Tests / 7 Assertions gruen.

## Widerlegte Hypothesen
- Cron-Env kaputt: Config laedt via Dotenv aus `.env`, cron-unabhaengig; 02:00-Lauf war erfolgreich.
- OMDb-Limit ueberschreibt: 401 -> `OmdbAuthorizationError` -> gefangen -> `null` -> `syncMovieRating` bricht ab, kein Write.
- TMDB-Sync nullt Spalten: `updateDetails` fasst `imdb_rating_average`/`rt_rating_average` nicht an.

## Verwandtes (nicht in diesem PR)
`MovieRepository::updateImdbRating` (Legacy `imdb:sync`, nirgends geschedult) hat denselben Null-Overwrite fuer `imdb_rating_average`. Kandidat fuer denselben Guard als Follow-up.

## CI-Hinweis
Dieser Branch basiert auf `main`, das noch die vorbestehende Static-Analysis-Debt enthaelt (phpcs/phpstan/psalm). `composer test` in der CI wird daher **wegen der Alt-Schuld** rot, nicht wegen dieses Fixes - der Fix selbst ist isoliert (2 Dateien, Unit-Tests gruen). PR #49 bereinigt genau diese Debt auf main; nach dessen Merge diesen Branch rebasen -> gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)