### PR TITLE
fix(api): enforce mandatory 2FA on API token creation

### DIFF
--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -6,17 +6,20 @@ use Movary\Domain\User\Exception\InvalidCredentials;
 use Movary\Domain\User\Exception\InvalidTotpCode;
 use Movary\Domain\User\Exception\MissingTotpCode;
 use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
 use Movary\Domain\User\UserApi;
 use Movary\Util\Json;
 use Movary\ValueObject\Http\Header;
 use Movary\ValueObject\Http\Request;
 use Movary\ValueObject\Http\Response;
+use Movary\ValueObject\Http\StatusCode;
 
 class AuthenticationController
 {
     public function __construct(
         private readonly Authentication $authenticationService,
         private readonly UserApi $userApi,
+        private readonly TwoFactorAuthenticationApi $twoFactorAuthenticationApi,
     ) {
     }
 
@@ -88,13 +91,32 @@ class AuthenticationController
             );
         }
 
+        $user = $userAndAuthToken['user'];
+
+        // Two-factor authentication is mandatory. The API cannot run the TOTP
+        // enrollment flow (that needs the web QR setup), so a user who has not
+        // set up 2FA yet must not receive an API token. Revoke the token that
+        // was just created and point them at the web setup. (Users who already
+        // have 2FA were verified by login() above.)
+        if ($this->twoFactorAuthenticationApi->findTotpUri($user->getId()) === null) {
+            $this->authenticationService->deleteToken($userAndAuthToken['token']);
+
+            return Response::createJson(
+                Json::encode([
+                    'error' => 'TwoFactorSetupRequired',
+                    'message' => 'Two-factor authentication is mandatory. Log in via the web interface to set it up before using the API.',
+                ]),
+                StatusCode::createForbidden(),
+            );
+        }
+
         return Response::createJson(
             Json::encode([
                 'authToken' => $userAndAuthToken['token'],
                 'user' => [
-                    'id' => $userAndAuthToken['user']->getId(),
-                    'name' => $userAndAuthToken['user']->getName(),
-                    'isAdmin' => $userAndAuthToken['user']->isAdmin(),
+                    'id' => $user->getId(),
+                    'name' => $user->getName(),
+                    'isAdmin' => $user->isAdmin(),
                 ]
             ]),
         );

--- a/tests/unit/HttpController/Api/AuthenticationControllerTest.php
+++ b/tests/unit/HttpController/Api/AuthenticationControllerTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Movary\HttpController\Api;
+
+use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
+use Movary\Domain\User\UserApi;
+use Movary\Domain\User\UserEntity;
+use Movary\HttpController\Api\AuthenticationController;
+use Movary\ValueObject\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthenticationController::class)]
+class AuthenticationControllerTest extends TestCase
+{
+    private Authentication&MockObject $authenticationService;
+
+    private TwoFactorAuthenticationApi&MockObject $twoFactorAuthenticationApi;
+
+    private AuthenticationController $subject;
+
+    protected function setUp() : void
+    {
+        $this->authenticationService = $this->createMock(Authentication::class);
+        $this->twoFactorAuthenticationApi = $this->createMock(TwoFactorAuthenticationApi::class);
+
+        $this->subject = new AuthenticationController(
+            $this->authenticationService,
+            $this->createMock(UserApi::class),
+            $this->twoFactorAuthenticationApi,
+        );
+    }
+
+    public function testCreateTokenRefusesUserWithoutTwoFactorAndRevokesTheToken() : void
+    {
+        $this->authenticationService->method('login')->willReturn([
+            'user' => $this->createUser(37),
+            'token' => 'freshly-created-token',
+        ]);
+        // Two-factor authentication is mandatory but this user has not set it up.
+        $this->twoFactorAuthenticationApi->method('findTotpUri')->with(37)->willReturn(null);
+
+        // The token that login() just created must be revoked so it cannot be used.
+        $this->authenticationService->expects(self::once())->method('deleteToken')->with('freshly-created-token');
+
+        $response = $this->subject->createToken($this->createTokenRequest());
+
+        self::assertSame(403, $response->getStatusCode()->getCode());
+        self::assertStringContainsString('TwoFactorSetupRequired', (string)$response->getBody());
+        self::assertStringNotContainsString('freshly-created-token', (string)$response->getBody());
+    }
+
+    public function testCreateTokenIssuesTokenForUserWithTwoFactor() : void
+    {
+        $this->authenticationService->method('login')->willReturn([
+            'user' => $this->createUser(37),
+            'token' => 'freshly-created-token',
+        ]);
+        $this->twoFactorAuthenticationApi->method('findTotpUri')->with(37)->willReturn('otpauth://totp/Pathary:zsmith?secret=ABC');
+
+        $this->authenticationService->expects(self::never())->method('deleteToken');
+
+        $response = $this->subject->createToken($this->createTokenRequest());
+
+        self::assertSame(200, $response->getStatusCode()->getCode());
+        self::assertStringContainsString('freshly-created-token', (string)$response->getBody());
+    }
+
+    private function createUser(int $id) : UserEntity&MockObject
+    {
+        $user = $this->createMock(UserEntity::class);
+        $user->method('getId')->willReturn($id);
+        $user->method('getName')->willReturn('zsmith');
+        $user->method('isAdmin')->willReturn(false);
+
+        return $user;
+    }
+
+    private function createTokenRequest() : Request&MockObject
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('getBody')->willReturn((string)json_encode([
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]));
+        $request->method('getHeaders')->willReturn(['X-Movary-Client' => 'test-client']);
+        $request->method('getUserAgent')->willReturn('test-agent');
+
+        return $request;
+    }
+}


### PR DESCRIPTION
Schliesst den API-2FA-Gap: die 2FA-Pflicht galt bisher nur im Web (Middleware `UserIsAuthenticated`).

## Problem
`POST /api/authentication/token` laeuft nicht durch die Web-Middleware. Ein User **ohne** eingerichtetes 2FA konnte mit email+password einen API-Token holen und damit die 2FA-Pflicht umgehen. (User **mit** 2FA waren nie betroffen - `login()` erzwingt deren TOTP/Recovery-Code auch am API-Pfad.)

## Fix
Nach erfolgreichem `login()` prueft `createToken`, ob der User ein TOTP konfiguriert hat. Falls nicht: der gerade erzeugte Token wird revoked und die Anfrage mit **403 `TwoFactorSetupRequired`** beantwortet, mit Verweis auf das Web-Setup (die API kann den TOTP-Enrollment-Flow mit QR-Code nicht ausfuehren).

## Test
`tests/unit/HttpController/Api/AuthenticationControllerTest.php`: no-2FA-User -> 403 + Token revoked; 2FA-User -> Token wird ausgegeben. Faellt gegen den alten Code (200 statt 403), besteht mit Fix. Volle Suite gruen (177 Tests / 397 Assertions).

## Kontext
Follow-up zum 2FA-Pflicht-Feature aus #49. Der zweite urspruenglich genannte Follow-up (`updateImdbRating`-Zwilling) stellte sich als Nicht-Bug heraus: `ImdbRating`-Felder sind non-nullable und `ImdbMovieRatingSync` schreibt bei fehlendem Rating gar nicht - kein Null-Overwrite moeglich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)