### PR TITLE
fix(auth): persistent brute-force rate limiting on login (#44)

### DIFF
--- a/db/migrations/mysql/20260706171500_add_login_attempts.php
+++ b/db/migrations/mysql/20260706171500_add_login_attempts.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddLoginAttempts extends AbstractMigration
+{
+    public function up(): void
+    {
+        if ($this->hasTable('login_attempts') === true) {
+            return;
+        }
+
+        $this->table('login_attempts')
+            ->addColumn('ip_hash', 'string', [
+                'limit' => 64,
+                'null' => false,
+                'comment' => 'SHA-256 hash of the client IP address',
+            ])
+            ->addColumn('attempted_at', 'datetime', [
+                'default' => 'CURRENT_TIMESTAMP',
+                'null' => false,
+            ])
+            ->addColumn('success', 'boolean', [
+                'default' => false,
+                'null' => false,
+                'comment' => 'Whether the authentication attempt succeeded',
+            ])
+            ->addColumn('ip_address', 'string', [
+                'limit' => 45,
+                'null' => true,
+                'comment' => 'Client IP (IPv4 or IPv6) for auditing',
+            ])
+            ->addIndex(['ip_hash', 'attempted_at'], ['name' => 'idx_ip_time'])
+            ->create();
+    }
+
+    public function down(): void
+    {
+        if ($this->hasTable('login_attempts') === true) {
+            $this->table('login_attempts')->drop()->save();
+        }
+    }
+}

--- a/db/migrations/sqlite/20260706171500_add_login_attempts.php
+++ b/db/migrations/sqlite/20260706171500_add_login_attempts.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddLoginAttempts extends AbstractMigration
+{
+    public function up(): void
+    {
+        if ($this->hasTable('login_attempts') === true) {
+            return;
+        }
+
+        $this->table('login_attempts')
+            ->addColumn('ip_hash', 'string', [
+                'limit' => 64,
+                'null' => false,
+                'comment' => 'SHA-256 hash of the client IP address',
+            ])
+            ->addColumn('attempted_at', 'datetime', [
+                'default' => 'CURRENT_TIMESTAMP',
+                'null' => false,
+            ])
+            ->addColumn('success', 'boolean', [
+                'default' => false,
+                'null' => false,
+                'comment' => 'Whether the authentication attempt succeeded',
+            ])
+            ->addColumn('ip_address', 'string', [
+                'limit' => 45,
+                'null' => true,
+                'comment' => 'Client IP (IPv4 or IPv6) for auditing',
+            ])
+            ->addIndex(['ip_hash', 'attempted_at'], ['name' => 'idx_ip_time'])
+            ->create();
+    }
+
+    public function down(): void
+    {
+        if ($this->hasTable('login_attempts') === true) {
+            $this->table('login_attempts')->drop()->save();
+        }
+    }
+}

--- a/src/HttpController/Api/AuthenticationController.php
+++ b/src/HttpController/Api/AuthenticationController.php
@@ -8,6 +8,8 @@ use Movary\Domain\User\Exception\MissingTotpCode;
 use Movary\Domain\User\Service\Authentication;
 use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
 use Movary\Domain\User\UserApi;
+use Movary\Service\Exception\LoginRateLimitExceeded;
+use Movary\Service\LoginRateLimiterService;
 use Movary\Util\Json;
 use Movary\ValueObject\Http\Header;
 use Movary\ValueObject\Http\Request;
@@ -20,32 +22,18 @@ class AuthenticationController
         private readonly Authentication $authenticationService,
         private readonly UserApi $userApi,
         private readonly TwoFactorAuthenticationApi $twoFactorAuthenticationApi,
+        private readonly LoginRateLimiterService $loginRateLimiter,
     ) {
     }
 
     public function createToken(Request $request) : Response
     {
         $tokenRequestBody = Json::decode($request->getBody());
-
-        if (isset($tokenRequestBody['email']) === false || isset($tokenRequestBody['password']) === false) {
-            return Response::createBadRequest(
-                Json::encode([
-                    'error' => 'MissingCredentials',
-                    'message' => 'Email or password is missing'
-                ]),
-                [Header::createContentTypeJson()],
-            );
-        }
-
         $headers = $request->getHeaders();
-        if (isset($headers['X-Movary-Client']) === false) {
-            return Response::createBadRequest(
-                Json::encode([
-                    'error' => 'MissingRequestHeader',
-                    'message' => 'Missing request header X-Movary-Client'
-                ]),
-                [Header::createContentTypeJson()],
-            );
+
+        $validationError = $this->validateTokenRequest($tokenRequestBody, $headers);
+        if ($validationError !== null) {
+            return $validationError;
         }
 
         $requestClient = $headers['X-Movary-Client'];
@@ -53,6 +41,22 @@ class AuthenticationController
         $recoveryCode = empty($tokenRequestBody['recoveryCode']) === true ? null : trim($tokenRequestBody['recoveryCode']);
         $rememberMe = $tokenRequestBody['rememberMe'] ?? false;
         $trustDevice = $tokenRequestBody['trustDevice'] ?? false;
+
+        // Persistent, IP-based brute-force protection. This endpoint is the only
+        // login choke point (the web login form posts here too) and runs before
+        // authentication, so a session-based limiter would be trivially bypassed.
+        $clientIp = $this->getClientIp();
+        try {
+            $this->loginRateLimiter->ensureNotRateLimited($clientIp);
+        } catch (LoginRateLimitExceeded $e) {
+            return Response::createJson(
+                Json::encode([
+                    'error' => 'RateLimitExceeded',
+                    'message' => $e->getMessage(),
+                ]),
+                StatusCode::createTooManyRequests(),
+            );
+        }
 
         try {
             $userAndAuthToken = $this->authenticationService->login(
@@ -74,6 +78,8 @@ class AuthenticationController
                 [Header::createContentTypeJson()],
             );
         } catch (InvalidTotpCode) {
+            $this->loginRateLimiter->logAttempt($clientIp, false);
+
             return Response::createUnauthorized(
                 Json::encode([
                     'error' => 'InvalidTotpCode',
@@ -82,6 +88,8 @@ class AuthenticationController
                 [Header::createContentTypeJson()],
             );
         } catch (InvalidCredentials $e) {
+            $this->loginRateLimiter->logAttempt($clientIp, false);
+
             return Response::createUnauthorized(
                 Json::encode([
                     'error' => 'InvalidCredentials',
@@ -90,6 +98,9 @@ class AuthenticationController
                 [Header::createContentTypeJson()],
             );
         }
+
+        // Credentials (and TOTP, if configured) were valid.
+        $this->loginRateLimiter->logAttempt($clientIp, true);
 
         $user = $userAndAuthToken['user'];
 
@@ -120,6 +131,48 @@ class AuthenticationController
                 ]
             ]),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $tokenRequestBody
+     * @param array<string, mixed> $headers
+     */
+    private function validateTokenRequest(array $tokenRequestBody, array $headers) : ?Response
+    {
+        if (isset($tokenRequestBody['email']) === false || isset($tokenRequestBody['password']) === false) {
+            return Response::createBadRequest(
+                Json::encode([
+                    'error' => 'MissingCredentials',
+                    'message' => 'Email or password is missing'
+                ]),
+                [Header::createContentTypeJson()],
+            );
+        }
+
+        if (isset($headers['X-Movary-Client']) === false) {
+            return Response::createBadRequest(
+                Json::encode([
+                    'error' => 'MissingRequestHeader',
+                    'message' => 'Missing request header X-Movary-Client'
+                ]),
+                [Header::createContentTypeJson()],
+            );
+        }
+
+        return null;
+    }
+
+    private function getClientIp() : string
+    {
+        // Prefer the real client IP behind a reverse proxy (e.g. NPM), otherwise
+        // fall back to the direct connection address.
+        if (empty($_SERVER['HTTP_X_FORWARDED_FOR']) === false) {
+            $forwardedIps = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+
+            return trim($forwardedIps[0]);
+        }
+
+        return $_SERVER['REMOTE_ADDR'] ?? 'unknown';
     }
 
     public function destroyToken(Request $request) : Response

--- a/src/Service/Exception/LoginRateLimitExceeded.php
+++ b/src/Service/Exception/LoginRateLimitExceeded.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Movary\Service\Exception;
+
+use RuntimeException;
+
+class LoginRateLimitExceeded extends RuntimeException
+{
+    public static function create(int $windowMinutes) : self
+    {
+        return new self(
+            sprintf('Too many failed login attempts. Please wait %d minutes and try again.', $windowMinutes),
+        );
+    }
+}

--- a/src/Service/LoginRateLimiterService.php
+++ b/src/Service/LoginRateLimiterService.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Movary\Service;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use Movary\Service\Exception\LoginRateLimitExceeded;
+
+/**
+ * Persistent, IP-based rate limiter for login attempts to slow down brute-force
+ * and credential-stuffing attacks against the token endpoint.
+ *
+ * Unlike the session-based RateLimiter, failed attempts are stored in the
+ * database, so an attacker cannot reset the counter by discarding the session.
+ * Keyed by IP (not account) to avoid a victim being locked out by a third party.
+ */
+class LoginRateLimiterService
+{
+    private const int MAX_FAILED_ATTEMPTS = 10;
+
+    private const int WINDOW_MINUTES = 15;
+
+    public function __construct(
+        private readonly Connection $dbConnection,
+    ) {
+    }
+
+    /**
+     * @throws LoginRateLimitExceeded if the IP has too many recent failed attempts
+     */
+    public function ensureNotRateLimited(string $ipAddress) : void
+    {
+        $windowStart = (new DateTime())->modify('-' . self::WINDOW_MINUTES . ' minutes');
+
+        $failedAttempts = (int)$this->dbConnection->createQueryBuilder()
+            ->select('COUNT(*)')
+            ->from('login_attempts')
+            ->where('ip_hash = :ip_hash')
+            ->andWhere('attempted_at >= :window_start')
+            ->andWhere('success = 0')
+            ->setParameter('ip_hash', $this->hashIp($ipAddress))
+            ->setParameter('window_start', $windowStart->format('Y-m-d H:i:s'))
+            ->executeQuery()
+            ->fetchOne();
+
+        if ($failedAttempts >= self::MAX_FAILED_ATTEMPTS) {
+            throw LoginRateLimitExceeded::create(self::WINDOW_MINUTES);
+        }
+    }
+
+    public function logAttempt(string $ipAddress, bool $success) : void
+    {
+        $this->dbConnection->insert('login_attempts', [
+            'ip_hash' => $this->hashIp($ipAddress),
+            'attempted_at' => (new DateTime())->format('Y-m-d H:i:s'),
+            'success' => $success === true ? 1 : 0,
+            'ip_address' => $ipAddress,
+        ]);
+    }
+
+    private function hashIp(string $ipAddress) : string
+    {
+        return hash('sha256', $ipAddress);
+    }
+}

--- a/tests/unit/HttpController/Api/AuthenticationControllerTest.php
+++ b/tests/unit/HttpController/Api/AuthenticationControllerTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Unit\Movary\HttpController\Api;
 
+use Movary\Domain\User\Exception\InvalidCredentials;
 use Movary\Domain\User\Service\Authentication;
 use Movary\Domain\User\Service\TwoFactorAuthenticationApi;
 use Movary\Domain\User\UserApi;
 use Movary\Domain\User\UserEntity;
 use Movary\HttpController\Api\AuthenticationController;
+use Movary\Service\Exception\LoginRateLimitExceeded;
+use Movary\Service\LoginRateLimiterService;
 use Movary\ValueObject\Http\Request;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -19,17 +22,21 @@ class AuthenticationControllerTest extends TestCase
 
     private TwoFactorAuthenticationApi&MockObject $twoFactorAuthenticationApi;
 
+    private LoginRateLimiterService&MockObject $loginRateLimiter;
+
     private AuthenticationController $subject;
 
     protected function setUp() : void
     {
         $this->authenticationService = $this->createMock(Authentication::class);
         $this->twoFactorAuthenticationApi = $this->createMock(TwoFactorAuthenticationApi::class);
+        $this->loginRateLimiter = $this->createMock(LoginRateLimiterService::class);
 
         $this->subject = new AuthenticationController(
             $this->authenticationService,
             $this->createMock(UserApi::class),
             $this->twoFactorAuthenticationApi,
+            $this->loginRateLimiter,
         );
     }
 
@@ -66,6 +73,46 @@ class AuthenticationControllerTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode()->getCode());
         self::assertStringContainsString('freshly-created-token', (string)$response->getBody());
+    }
+
+    public function testCreateTokenIsRefusedWhenRateLimited() : void
+    {
+        $this->loginRateLimiter->method('ensureNotRateLimited')->willThrowException(LoginRateLimitExceeded::create(15));
+
+        // A rate-limited request must never reach authentication.
+        $this->authenticationService->expects(self::never())->method('login');
+
+        $response = $this->subject->createToken($this->createTokenRequest());
+
+        self::assertSame(429, $response->getStatusCode()->getCode());
+        self::assertStringContainsString('RateLimitExceeded', (string)$response->getBody());
+    }
+
+    public function testFailedLoginIsRecordedAsAttempt() : void
+    {
+        $this->authenticationService->method('login')->willThrowException(InvalidCredentials::create());
+
+        // A wrong password must be recorded so repeated failures trip the limiter.
+        $this->loginRateLimiter->expects(self::once())->method('logAttempt')->with(self::anything(), false);
+
+        $response = $this->subject->createToken($this->createTokenRequest());
+
+        self::assertSame(401, $response->getStatusCode()->getCode());
+    }
+
+    public function testSuccessfulLoginIsRecordedAsAttempt() : void
+    {
+        $this->authenticationService->method('login')->willReturn([
+            'user' => $this->createUser(37),
+            'token' => 'freshly-created-token',
+        ]);
+        $this->twoFactorAuthenticationApi->method('findTotpUri')->willReturn('otpauth://totp/Pathary:zsmith?secret=ABC');
+
+        $this->loginRateLimiter->expects(self::once())->method('logAttempt')->with(self::anything(), true);
+
+        $response = $this->subject->createToken($this->createTokenRequest());
+
+        self::assertSame(200, $response->getStatusCode()->getCode());
     }
 
     private function createUser(int $id) : UserEntity&MockObject


### PR DESCRIPTION
Schliesst GH #44 (P1, area-auth): der Login-Endpoint hatte keine Brute-Force-Bremse.

## Problem
`POST /api/authentication/token` (einziger Login-Choke-Point, auch das Web-Login-Formular postet dorthin) war ungebremst. Der vorhandene `RateLimiter` ist **session-basiert** und hier wirkungslos: er laeuft vor der Authentifizierung, ein Angreifer verwirft einfach die Session und der Counter resettet.

## Loesung (nach dem Muster von `PasswordSetupRateLimiterService`)
- **Neue `login_attempts`-Tabelle** (Phinx-Migration mysql + sqlite), keyed per SHA-256-Hash der Client-IP, speichert `attempted_at` + `success`.
- **`LoginRateLimiterService`**: `ensureNotRateLimited()` wirft nach 10 fehlgeschlagenen Versuchen einer IP in 15 Minuten; `logAttempt()` protokolliert jeden Versuch.
- **`createToken`** prueft vor dem Login (429 bei Ueberschreitung), zaehlt Fehlversuche (falsches Passwort / falsches TOTP) und Erfolge. `MissingTotpCode` zaehlt **nicht** (Passwort war korrekt, nur der 2FA-Schritt fehlt noch).

## Design
- **Keyed per IP, nicht Account** -> kein Account-Lockout-DoS durch Dritte.
- **X-Forwarded-For** bevorzugt (echte Client-IP hinter NPM), sonst REMOTE_ADDR.
- Persistent in DB -> Session-Verwerfen umgeht die Bremse nicht.

## Verifikation
End-to-end gegen die laufende App: Versuche 1-10 -> 401, ab 11 -> **429** (DB: genau 10 Failure-Rows, danach Block vor dem Login). 3 neue Unit-Tests (rate-limited -> 429, Fehlversuch geloggt, Erfolg geloggt). Volle Suite gruen: 180 Tests / 408 Assertions, phpcs/phpstan/psalm clean.

## Kontext
Follow-up aus dem Vault/GitHub-Abgleich. Naechste offene Kandidaten (nicht in diesem PR): SMTP-PW at-rest verschluesseln (#15), Performance-Audit (#2), Restart-Policy auf unless-stopped (Ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)