### PR TITLE
fix(email): encrypt SMTP password at rest (#15)

### DIFF
--- a/src/Service/ServerSettings.php
+++ b/src/Service/ServerSettings.php
@@ -53,6 +53,7 @@ class ServerSettings
     public function __construct(
         private readonly Config $config,
         private readonly Connection $dbConnection,
+        private readonly SmtpPasswordCipher $smtpPasswordCipher,
     ) {
     }
 
@@ -118,7 +119,12 @@ class ServerSettings
 
     public function getSmtpPassword() : ?string
     {
-        return $this->getByKey(self::SMTP_PASSWORD);
+        $storedValue = $this->getByKey(self::SMTP_PASSWORD);
+        if ($storedValue === null) {
+            return null;
+        }
+
+        return $this->smtpPasswordCipher->decryptFromStorage($storedValue);
     }
 
     public function getSmtpPort() : ?int
@@ -294,7 +300,7 @@ class ServerSettings
 
     public function setSmtpPassword(string $smtpPassword) : void
     {
-        $this->updateValue(self::SMTP_PASSWORD, $smtpPassword);
+        $this->updateValue(self::SMTP_PASSWORD, $this->smtpPasswordCipher->encryptForStorage($smtpPassword));
     }
 
     public function setSmtpPort(int $smtpPort) : void

--- a/src/Service/SmtpPasswordCipher.php
+++ b/src/Service/SmtpPasswordCipher.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Movary\Service;
+
+use RuntimeException;
+
+/**
+ * Encrypts the SMTP password for at-rest storage in the generic server_setting
+ * value column, without a schema change.
+ *
+ * Encrypted values are wrapped in a self-describing envelope
+ * ("enc:v1:<base64 iv>:<base64 ciphertext>") so that reads can tell an
+ * encrypted value apart from a legacy plaintext one (or an env-provided
+ * password, which is never encrypted). When no encryption key is configured the
+ * password is stored as plaintext, matching the previous behaviour, so a
+ * basic-SMTP setup without an encryption key keeps working.
+ */
+class SmtpPasswordCipher
+{
+    private const string ENVELOPE_PREFIX = 'enc:v1:';
+
+    public function __construct(
+        private readonly EncryptionService $encryptionService,
+    ) {
+    }
+
+    public function encryptForStorage(string $plaintext) : string
+    {
+        // EncryptionService::encrypt() rejects an empty string, and without a
+        // key we cannot encrypt at all - keep the previous plaintext behaviour.
+        if ($plaintext === '' || $this->encryptionService->isEncryptionKeyConfigured() === false) {
+            return $plaintext;
+        }
+
+        $encrypted = $this->encryptionService->encrypt($plaintext);
+
+        return self::ENVELOPE_PREFIX . $encrypted['iv'] . ':' . $encrypted['encrypted'];
+    }
+
+    public function decryptFromStorage(string $storedValue) : string
+    {
+        // Legacy plaintext values and env-provided passwords carry no envelope.
+        if (str_starts_with($storedValue, self::ENVELOPE_PREFIX) === false) {
+            return $storedValue;
+        }
+
+        $parts = explode(':', substr($storedValue, strlen(self::ENVELOPE_PREFIX)), 2);
+        if (count($parts) !== 2) {
+            return $storedValue;
+        }
+
+        [$iv, $ciphertext] = $parts;
+
+        try {
+            return $this->encryptionService->decrypt($ciphertext, $iv);
+        } catch (RuntimeException) {
+            // Missing/rotated key or corrupted payload: return the raw stored
+            // value rather than breaking the email flow with an exception.
+            return $storedValue;
+        }
+    }
+}

--- a/tests/unit/Service/SmtpPasswordCipherTest.php
+++ b/tests/unit/Service/SmtpPasswordCipherTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Movary\Service;
+
+use Movary\Service\EncryptionService;
+use Movary\Service\SmtpPasswordCipher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(SmtpPasswordCipher::class)]
+class SmtpPasswordCipherTest extends TestCase
+{
+    private EncryptionService&MockObject $encryptionService;
+
+    private SmtpPasswordCipher $subject;
+
+    protected function setUp() : void
+    {
+        $this->encryptionService = $this->createMock(EncryptionService::class);
+        $this->subject = new SmtpPasswordCipher($this->encryptionService);
+    }
+
+    public function testEncryptsAndDecryptsRoundTripWhenKeyConfigured() : void
+    {
+        $this->encryptionService->method('isEncryptionKeyConfigured')->willReturn(true);
+        $this->encryptionService->method('encrypt')->with('s3cret')->willReturn([
+            'encrypted' => 'CIPHER',
+            'iv' => 'IVDATA',
+        ]);
+
+        $stored = $this->subject->encryptForStorage('s3cret');
+
+        self::assertSame('enc:v1:IVDATA:CIPHER', $stored);
+
+        $this->encryptionService->method('decrypt')->with('CIPHER', 'IVDATA')->willReturn('s3cret');
+
+        self::assertSame('s3cret', $this->subject->decryptFromStorage($stored));
+    }
+
+    public function testStoresPlaintextWhenNoKeyConfigured() : void
+    {
+        $this->encryptionService->method('isEncryptionKeyConfigured')->willReturn(false);
+        $this->encryptionService->expects(self::never())->method('encrypt');
+
+        self::assertSame('s3cret', $this->subject->encryptForStorage('s3cret'));
+    }
+
+    public function testEmptyPasswordIsNeverEncrypted() : void
+    {
+        $this->encryptionService->method('isEncryptionKeyConfigured')->willReturn(true);
+        $this->encryptionService->expects(self::never())->method('encrypt');
+
+        self::assertSame('', $this->subject->encryptForStorage(''));
+    }
+
+    public function testDecryptReturnsLegacyPlaintextUnchanged() : void
+    {
+        $this->encryptionService->expects(self::never())->method('decrypt');
+
+        self::assertSame('legacy-plaintext', $this->subject->decryptFromStorage('legacy-plaintext'));
+    }
+
+    public function testDecryptFallsBackToRawValueWhenDecryptionFails() : void
+    {
+        $this->encryptionService->method('decrypt')->willThrowException(new RuntimeException('key missing'));
+
+        $enveloped = 'enc:v1:IVDATA:CIPHER';
+
+        self::assertSame($enveloped, $this->subject->decryptFromStorage($enveloped));
+    }
+}


### PR DESCRIPTION
Schliesst GH #15 (P2, security/area-email): das SMTP-Passwort lag Klartext in `server_setting.value`.

## Loesung
Verschluesselung at-rest via bestehendem `EncryptionService` (AES-256-CBC, wie OAuth-Secrets). Neue `SmtpPasswordCipher` legt den verschluesselten Wert als **selbstbeschreibenden Envelope** (`enc:v1:<base64 iv>:<base64 cipher>`) im bestehenden `value`-Feld ab -> **kein Schema-Change**, Reads unterscheiden verschluesselt / Legacy-Plaintext / env-Passwort.

- `setSmtpPassword` verschluesselt **wenn ein Encryption-Key konfiguriert ist**; ohne Key -> Plaintext (unveraendert), damit Basic-SMTP-Setups ohne OAuth-Key weiter funktionieren.
- `getSmtpPassword` entschluesselt Envelope-Werte, gibt Legacy-Plaintext unveraendert zurueck; ein Decrypt-Fehler (rotierter/fehlender Key) faellt auf den Rohwert zurueck statt den Mail-Flow zu brechen.

## Kein Migrationsrisiko
Keine Migration noetig. Bestehende Klartext-Passwoerter funktionieren weiter und werden beim **naechsten Speichern** verschluesselt. Die 5 Aufrufer von `getSmtpPassword` sind unveraendert (bekommen weiterhin Klartext).

## Verifikation
End-to-end gegen die laufende App: **mit** Key ist der gespeicherte Wert enveloped, enthaelt keinen Klartext und round-trippt korrekt; **ohne** Key Plaintext-Fallback. 5 Unit-Tests (Round-Trip, No-Key, leeres Passwort, Legacy-Plaintext, Decrypt-Failure-Fallback). Volle Suite gruen: 185 Tests / 420 Assertions, phpcs/phpstan/psalm clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)