### PR TITLE
feat(i18n): DE/EN translation foundation + language switcher

### DIFF
--- a/resources/translations/de.php
+++ b/resources/translations/de.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+// Deutscher Nachrichtenkatalog (Schweizer Rechtschreibung: kein Eszett, echte Umlaute).
+return [
+    'nav.search' => 'Suche',
+    'nav.search_placeholder' => 'Filme suchen...',
+    'nav.all_movies' => 'Alle Filme',
+    'nav.profile' => 'Profil',
+    'nav.admin' => 'Admin',
+    'nav.logout' => 'Abmelden',
+    'nav.login' => 'Anmelden',
+    'nav.dark_mode' => 'Dunkelmodus',
+    'nav.toggle_dark_mode' => 'Dunkelmodus umschalten',
+    'nav.toggle_navigation' => 'Navigation umschalten',
+
+    'lang.label' => 'Sprache',
+    'lang.german' => 'Deutsch',
+    'lang.english' => 'English',
+];

--- a/resources/translations/en.php
+++ b/resources/translations/en.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+// English message catalog. Keys are dot-namespaced by area (nav.*, lang.*, ...).
+return [
+    'nav.search' => 'Search',
+    'nav.search_placeholder' => 'Search movies...',
+    'nav.all_movies' => 'All Movies',
+    'nav.profile' => 'Profile',
+    'nav.admin' => 'Admin',
+    'nav.logout' => 'Logout',
+    'nav.login' => 'Login',
+    'nav.dark_mode' => 'Dark mode',
+    'nav.toggle_dark_mode' => 'Toggle dark mode',
+    'nav.toggle_navigation' => 'Toggle navigation',
+
+    'lang.label' => 'Language',
+    'lang.german' => 'Deutsch',
+    'lang.english' => 'English',
+];

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -21,6 +21,7 @@ function addWebRoutes(RouterService $routerService, FastRoute\RouteCollector $ro
     # Public Home #
     ###############
     $routes->add('GET', '/', [Web\PublicHomeController::class, 'index'], [Web\Middleware\RedirectToInitIfNeeded::class]);
+    $routes->add('GET', '/language/{locale:[a-z]{2}}', [Web\LanguageController::class, 'switchLanguage']);
     $routes->add('GET', '/movie/{id:[0-9]+}', [Web\PublicMovieController::class, 'detail']);
     $routes->add('POST', '/movie/{id:[0-9]+}/rate', [Web\RateMovieController::class, 'rate'], [Web\Middleware\UserIsAuthenticated::class, Web\Middleware\CsrfProtection::class]);
     $routes->add('POST', '/movie/{id:[0-9]+}/rate/delete', [Web\RateMovieController::class, 'deleteRating'], [Web\Middleware\UserIsAuthenticated::class, Web\Middleware\CsrfProtection::class]);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -361,6 +361,11 @@ class Factory
         // CSRF token function for form protection
         $twig->addFunction(new TwigFunction('csrf_token', [$container->get(CsrfTokenService::class), 'generateToken']));
 
+        // i18n: t('key') translates, locale() returns the active locale (de|en)
+        $translator = $container->get(Service\Translation\Translator::class);
+        $twig->addFunction(new TwigFunction('t', [$translator, 'trans']));
+        $twig->addFunction(new TwigFunction('locale', [$translator, 'getLocale']));
+
         return $twig;
     }
 

--- a/src/HttpController/Web/LanguageController.php
+++ b/src/HttpController/Web/LanguageController.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Movary\HttpController\Web;
+
+use Movary\Service\Translation\Translator;
+use Movary\Util\SessionWrapper;
+use Movary\ValueObject\Http\Request;
+use Movary\ValueObject\Http\Response;
+
+class LanguageController
+{
+    public function __construct(
+        private readonly SessionWrapper $sessionWrapper,
+        private readonly Translator $translator,
+    ) {
+    }
+
+    public function switchLanguage(Request $request) : Response
+    {
+        $locale = (string)($request->getRouteParameters()['locale'] ?? '');
+        if ($this->translator->isSupported($locale) === true) {
+            $this->sessionWrapper->set('locale', $locale);
+        }
+
+        return Response::createSeeOther($this->resolveRedirectTarget($request));
+    }
+
+    private function resolveRedirectTarget(Request $request) : string
+    {
+        // Return to the page the switch was triggered from, but only ever as a
+        // same-site relative path (drop scheme/host) to avoid an open redirect.
+        $referer = $request->getHttpReferer();
+        if ($referer === null || $referer === '') {
+            return '/';
+        }
+
+        $path = parse_url($referer, PHP_URL_PATH);
+        if (is_string($path) === false || str_starts_with($path, '/') === false) {
+            return '/';
+        }
+
+        $query = parse_url($referer, PHP_URL_QUERY);
+
+        return $path . (is_string($query) === true && $query !== '' ? '?' . $query : '');
+    }
+}

--- a/src/Service/Translation/Translator.php
+++ b/src/Service/Translation/Translator.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Movary\Service\Translation;
+
+use Movary\Util\SessionWrapper;
+
+/**
+ * Lightweight message translator backed by flat PHP catalogs in
+ * resources/translations/<locale>.php.
+ *
+ * The active locale is resolved lazily (once per request) so templates can call
+ * t(...) without every route wiring in a locale middleware. Etappe 1 resolves
+ * from the session (set by the language switcher); a later stage layers the
+ * per-user profile preference on top.
+ */
+class Translator
+{
+    private const string DEFAULT_LOCALE = 'de';
+
+    private const array SUPPORTED_LOCALES = ['de', 'en'];
+
+    private readonly string $translationsDirectory;
+
+    /** @var array<string, array<string, string>> */
+    private array $catalogs = [];
+
+    private ?string $locale = null;
+
+    public function __construct(
+        private readonly SessionWrapper $sessionWrapper,
+        ?string $translationsDirectory = null,
+    ) {
+        $this->translationsDirectory = $translationsDirectory ?? __DIR__ . '/../../../resources/translations';
+    }
+
+    /**
+     * @param array<string, string|int> $replacements Values for {placeholder} tokens
+     */
+    public function trans(string $key, array $replacements = []) : string
+    {
+        $translation = $this->getCatalog($this->getLocale())[$key]
+            ?? $this->getCatalog(self::DEFAULT_LOCALE)[$key]
+            ?? $key;
+
+        foreach ($replacements as $placeholder => $value) {
+            $translation = str_replace('{' . $placeholder . '}', (string)$value, $translation);
+        }
+
+        return $translation;
+    }
+
+    public function getLocale() : string
+    {
+        if ($this->locale !== null) {
+            return $this->locale;
+        }
+
+        $sessionLocale = $this->sessionWrapper->find('locale');
+        $this->locale = is_string($sessionLocale) && $this->isSupported($sessionLocale)
+            ? $sessionLocale
+            : self::DEFAULT_LOCALE;
+
+        return $this->locale;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSupportedLocales() : array
+    {
+        return self::SUPPORTED_LOCALES;
+    }
+
+    public function isSupported(string $locale) : bool
+    {
+        return in_array($locale, self::SUPPORTED_LOCALES, true);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getCatalog(string $locale) : array
+    {
+        if (isset($this->catalogs[$locale]) === false) {
+            $file = $this->translationsDirectory . '/' . $locale . '.php';
+            $this->catalogs[$locale] = is_file($file) === true ? (array)require $file : [];
+        }
+
+        return $this->catalogs[$locale];
+    }
+}

--- a/templates/partials/language_switcher.twig
+++ b/templates/partials/language_switcher.twig
@@ -1,0 +1,4 @@
+<div class="btn-group btn-group-sm" role="group" aria-label="{{ t('lang.label') }}">
+    <a href="{{ applicationUrl }}/language/de" class="btn btn-outline-light{% if locale() == 'de' %} active{% endif %}" title="{{ t('lang.german') }}">DE</a>
+    <a href="{{ applicationUrl }}/language/en" class="btn btn-outline-light{% if locale() == 'en' %} active{% endif %}" title="{{ t('lang.english') }}">EN</a>
+</div>

--- a/templates/partials/navbar_app.twig
+++ b/templates/partials/navbar_app.twig
@@ -11,36 +11,39 @@
             <span>{{ applicationName ?? 'Pathary' }}</span>
         </a>
 
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarAppContent" aria-controls="navbarAppContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarAppContent" aria-controls="navbarAppContent" aria-expanded="false" aria-label="{{ t('nav.toggle_navigation') }}">
             <span class="navbar-toggler-icon"></span>
         </button>
 
         <div class="collapse navbar-collapse" id="navbarAppContent">
             <form class="d-flex mx-auto my-2 my-lg-0" role="search" style="max-width: 400px; width: 100%;" action="{{ applicationUrl }}/search" method="get">
-                <input class="form-control" type="search" name="q" placeholder="Search movies..." aria-label="Search">
+                <input class="form-control" type="search" name="q" placeholder="{{ t('nav.search_placeholder') }}" aria-label="{{ t('nav.search') }}">
             </form>
 
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-center">
                 <li class="nav-item me-2">
-                    <div class="form-check form-switch mb-0" title="Toggle dark mode">
+                    {% include 'partials/language_switcher.twig' %}
+                </li>
+                <li class="nav-item me-2">
+                    <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
                         <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
-                        <label class="form-check-label visually-hidden" for="darkModeToggle">Dark mode</label>
+                        <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>
                         <span id="themeIcon" style="font-size: 1.1rem;">🌙</span>
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ applicationUrl }}/movies">All Movies</a>
+                    <a class="nav-link" href="{{ applicationUrl }}/movies">{{ t('nav.all_movies') }}</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ applicationUrl }}/profile">Profile</a>
+                    <a class="nav-link" href="{{ applicationUrl }}/profile">{{ t('nav.profile') }}</a>
                 </li>
                 {% if currentUserIsAdmin %}
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ applicationUrl }}/admin"><i class="bi bi-shield-lock me-1"></i>Admin</a>
+                    <a class="nav-link" href="{{ applicationUrl }}/admin"><i class="bi bi-shield-lock me-1"></i>{{ t('nav.admin') }}</a>
                 </li>
                 {% endif %}
                 <li class="nav-item">
-                    <button class="nav-link btn btn-link" onclick="logoutAndRedirect()" style="cursor: pointer;">Logout</button>
+                    <button class="nav-link btn btn-link" onclick="logoutAndRedirect()" style="cursor: pointer;">{{ t('nav.logout') }}</button>
                 </li>
             </ul>
         </div>

--- a/templates/partials/navbar_public.twig
+++ b/templates/partials/navbar_public.twig
@@ -5,13 +5,14 @@
             <span>{{ applicationName ?? 'Pathary' }}</span>
         </a>
         <div class="d-flex align-items-center gap-3">
-            <div class="form-check form-switch mb-0" title="Toggle dark mode">
+            {% include 'partials/language_switcher.twig' %}
+            <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
                 <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
-                <label class="form-check-label visually-hidden" for="darkModeToggle">Dark mode</label>
+                <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>
                 <span id="themeIcon" style="font-size: 1.1rem;">🌙</span>
             </div>
             <a href="{{ applicationUrl }}/login" class="btn btn-warning" style="background-color: var(--pathe-yellow); border-color: var(--pathe-yellow); color: var(--pathe-dark);">
-                Login
+                {{ t('nav.login') }}
             </a>
         </div>
     </div>

--- a/tests/unit/Service/Translation/TranslatorTest.php
+++ b/tests/unit/Service/Translation/TranslatorTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Movary\Service\Translation;
+
+use Movary\Service\Translation\Translator;
+use Movary\Util\SessionWrapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Translator::class)]
+class TranslatorTest extends TestCase
+{
+    public function testTranslatesToGermanByDefault() : void
+    {
+        self::assertSame('Alle Filme', $this->translatorWithSessionLocale(null)->trans('nav.all_movies'));
+    }
+
+    public function testTranslatesToEnglishWhenSessionLocaleIsEnglish() : void
+    {
+        self::assertSame('All Movies', $this->translatorWithSessionLocale('en')->trans('nav.all_movies'));
+    }
+
+    public function testUnsupportedSessionLocaleFallsBackToDefault() : void
+    {
+        self::assertSame('de', $this->translatorWithSessionLocale('fr')->getLocale());
+    }
+
+    public function testMissingKeyReturnsTheKeyItself() : void
+    {
+        self::assertSame('nav.does_not_exist', $this->translatorWithSessionLocale('en')->trans('nav.does_not_exist'));
+    }
+
+    public function testReplacementsAreApplied() : void
+    {
+        $directory = sys_get_temp_dir() . '/translator_test_' . uniqid('', true);
+        mkdir($directory);
+        file_put_contents($directory . '/en.php', "<?php return ['greeting' => 'Hello {name}'];");
+
+        try {
+            $session = $this->createMock(SessionWrapper::class);
+            $session->method('find')->willReturn('en');
+            $translator = new Translator($session, $directory);
+
+            self::assertSame('Hello Ben', $translator->trans('greeting', ['name' => 'Ben']));
+        } finally {
+            unlink($directory . '/en.php');
+            rmdir($directory);
+        }
+    }
+
+    private function translatorWithSessionLocale(?string $sessionLocale) : Translator
+    {
+        $session = $this->createMock(SessionWrapper::class);
+        $session->method('find')->with('locale')->willReturn($sessionLocale);
+
+        return new Translator($session);
+    }
+}


### PR DESCRIPTION
Erste Etappe der Deutsch/Englisch-Internationalisierung. Pathary hatte kein i18n - alle Strings hart English.

## Was drin ist
- **Kataloge** `resources/translations/{de,en}.php` (Key -> Text; Deutsch in Schweizer Rechtschreibung: kein Eszett, echte Umlaute)
- **Translator-Service**: loest die Locale **lazy** (einmal pro Request) aus der Session auf -> Templates rufen `t(key)` ohne Locale-Middleware in jeder Route. Fehlende Keys -> Default-Locale -> Key.
- **Twig-Funktionen** `t()` und `locale()`
- **LanguageController** + `GET /language/{locale}`: setzt Session-Locale, Redirect zurueck auf die Referer-Seite (nur same-site relativ, kein Open-Redirect)
- **DE/EN-Switcher** (Partial) neben dem Theme-Toggle in beiden Navbars, aktive Locale hervorgehoben; Nav-Strings via `t()`

Default-Locale ist **Deutsch**.

## Naechste Etappen (eigene PRs)
1. **Pro-User-Persistenz**: `user.language`-Spalte + Profil-Einstellung (Switch merkt sich pro User statt nur Session)
2..n. **Bulk-Uebersetzung** der restlichen ~101 Templates in Abschnitten (Movie-Seiten, Admin, Settings, Profil, Emails)

## Verifikation
End-to-end: Umschalten auf EN rendert die Nav Englisch, zurueck auf DE Deutsch; aktiver Switcher-Button korrekt. Kataloge bei Paritaet (13/13). Volle Suite gruen: 190 Tests / 429 Assertions, phpcs/phpstan/psalm clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)