### PR TITLE
feat(i18n): persist language preference per user

### DIFF
--- a/db/migrations/mysql/20260706180000_add_user_language.php
+++ b/db/migrations/mysql/20260706180000_add_user_language.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddUserLanguage extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('user');
+
+        if ($table->hasColumn('language') === true) {
+            return;
+        }
+
+        $table
+            ->addColumn('language', 'string', [
+                'limit' => 5,
+                'null' => true,
+                'default' => null,
+                'comment' => 'Preferred UI language (e.g. de, en); null uses the server default',
+            ])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $table = $this->table('user');
+
+        if ($table->hasColumn('language') === true) {
+            $table->removeColumn('language')->update();
+        }
+    }
+}

--- a/db/migrations/sqlite/20260706180000_add_user_language.php
+++ b/db/migrations/sqlite/20260706180000_add_user_language.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddUserLanguage extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('user');
+
+        if ($table->hasColumn('language') === true) {
+            return;
+        }
+
+        $table
+            ->addColumn('language', 'string', [
+                'limit' => 5,
+                'null' => true,
+                'default' => null,
+                'comment' => 'Preferred UI language (e.g. de, en); null uses the server default',
+            ])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $table = $this->table('user');
+
+        if ($table->hasColumn('language') === true) {
+            $table->removeColumn('language')->update();
+        }
+    }
+}

--- a/src/Domain/User/Service/Authentication.php
+++ b/src/Domain/User/Service/Authentication.php
@@ -280,6 +280,13 @@ class Authentication
         if ($deviceName === self::PATHARY_WEB_CLIENT) {
             $this->setAuthenticationCookieAndNewSession($user->getId(), $token, $authTokenExpirationDate);
 
+            // Apply the user's saved language preference to the fresh session, so
+            // the UI renders in their language across logins and devices.
+            $language = $this->userApi->findLanguage($user->getId());
+            if ($language !== null && $language !== '') {
+                $this->sessionWrapper->set('locale', $language);
+            }
+
             // Create trusted device if requested and 2FA is enabled
             if ($trustDevice === true && $this->userApi->findTotpUri($user->getId()) !== null) {
                 $deviceToken = $this->trustedDeviceService->createTrustedDevice(

--- a/src/Domain/User/UserApi.php
+++ b/src/Domain/User/UserApi.php
@@ -376,6 +376,16 @@ class UserApi
         $this->repository->updateDateFormatId($userId, $dateFormat);
     }
 
+    public function findLanguage(int $userId) : ?string
+    {
+        return $this->repository->findLanguage($userId);
+    }
+
+    public function updateLanguage(int $userId, ?string $language) : void
+    {
+        $this->repository->updateLanguage($userId, $language);
+    }
+
     public function updateDisplayCharacterNames(int $userId, bool $displayCharacterNames) : void
     {
         $this->repository->updateDisplayCharacterNames($userId, $displayCharacterNames);

--- a/src/Domain/User/UserRepository.php
+++ b/src/Domain/User/UserRepository.php
@@ -632,6 +632,29 @@ class UserRepository
         );
     }
 
+    public function findLanguage(int $userId) : ?string
+    {
+        $language = $this->dbConnection->fetchOne(
+            'SELECT language FROM `user` WHERE id = ?',
+            [$userId],
+        );
+
+        return $language === false || $language === null ? null : (string)$language;
+    }
+
+    public function updateLanguage(int $userId, ?string $language) : void
+    {
+        $this->dbConnection->update(
+            'user',
+            [
+                'language' => $language,
+            ],
+            [
+                'id' => $userId,
+            ],
+        );
+    }
+
     public function updateDisplayCharacterNames(int $userId, bool $displayCharacterNames) : void
     {
         $this->dbConnection->update(

--- a/src/HttpController/Web/LanguageController.php
+++ b/src/HttpController/Web/LanguageController.php
@@ -2,6 +2,8 @@
 
 namespace Movary\HttpController\Web;
 
+use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\UserApi;
 use Movary\Service\Translation\Translator;
 use Movary\Util\SessionWrapper;
 use Movary\ValueObject\Http\Request;
@@ -12,6 +14,8 @@ class LanguageController
     public function __construct(
         private readonly SessionWrapper $sessionWrapper,
         private readonly Translator $translator,
+        private readonly Authentication $authenticationService,
+        private readonly UserApi $userApi,
     ) {
     }
 
@@ -20,6 +24,12 @@ class LanguageController
         $locale = (string)($request->getRouteParameters()['locale'] ?? '');
         if ($this->translator->isSupported($locale) === true) {
             $this->sessionWrapper->set('locale', $locale);
+
+            // Persist the choice for logged-in users so it survives new sessions
+            // and follows them across devices.
+            if ($this->authenticationService->isUserAuthenticatedWithCookie() === true) {
+                $this->userApi->updateLanguage($this->authenticationService->getCurrentUserId(), $locale);
+            }
         }
 
         return Response::createSeeOther($this->resolveRedirectTarget($request));

--- a/tests/unit/HttpController/Web/LanguageControllerTest.php
+++ b/tests/unit/HttpController/Web/LanguageControllerTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Movary\HttpController\Web;
+
+use Movary\Domain\User\Service\Authentication;
+use Movary\Domain\User\UserApi;
+use Movary\HttpController\Web\LanguageController;
+use Movary\Service\Translation\Translator;
+use Movary\Util\SessionWrapper;
+use Movary\ValueObject\Http\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LanguageController::class)]
+class LanguageControllerTest extends TestCase
+{
+    private SessionWrapper&MockObject $sessionWrapper;
+
+    private Translator&MockObject $translator;
+
+    private Authentication&MockObject $authenticationService;
+
+    private UserApi&MockObject $userApi;
+
+    private LanguageController $subject;
+
+    protected function setUp() : void
+    {
+        $this->sessionWrapper = $this->createMock(SessionWrapper::class);
+        $this->translator = $this->createMock(Translator::class);
+        $this->authenticationService = $this->createMock(Authentication::class);
+        $this->userApi = $this->createMock(UserApi::class);
+
+        $this->subject = new LanguageController(
+            $this->sessionWrapper,
+            $this->translator,
+            $this->authenticationService,
+            $this->userApi,
+        );
+    }
+
+    public function testSwitchPersistsLanguageForAuthenticatedUser() : void
+    {
+        $this->translator->method('isSupported')->with('en')->willReturn(true);
+        $this->authenticationService->method('isUserAuthenticatedWithCookie')->willReturn(true);
+        $this->authenticationService->method('getCurrentUserId')->willReturn(37);
+
+        $this->sessionWrapper->expects(self::once())->method('set')->with('locale', 'en');
+        $this->userApi->expects(self::once())->method('updateLanguage')->with(37, 'en');
+
+        $response = $this->subject->switchLanguage($this->request('en'));
+
+        self::assertSame(303, $response->getStatusCode()->getCode());
+    }
+
+    public function testSwitchDoesNotPersistForGuest() : void
+    {
+        $this->translator->method('isSupported')->with('en')->willReturn(true);
+        $this->authenticationService->method('isUserAuthenticatedWithCookie')->willReturn(false);
+
+        $this->sessionWrapper->expects(self::once())->method('set')->with('locale', 'en');
+        $this->userApi->expects(self::never())->method('updateLanguage');
+
+        $this->subject->switchLanguage($this->request('en'));
+    }
+
+    public function testUnsupportedLocaleIsIgnored() : void
+    {
+        $this->translator->method('isSupported')->with('fr')->willReturn(false);
+
+        $this->sessionWrapper->expects(self::never())->method('set');
+        $this->userApi->expects(self::never())->method('updateLanguage');
+
+        $response = $this->subject->switchLanguage($this->request('fr'));
+
+        self::assertSame(303, $response->getStatusCode()->getCode());
+    }
+
+    private function request(string $locale) : Request&MockObject
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('getRouteParameters')->willReturn(['locale' => $locale]);
+        $request->method('getHttpReferer')->willReturn(null);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
Zweite i18n-Etappe: die Sprachwahl merkt sich **pro User** statt nur in der Session.

## Was drin ist
- **Migration** `user.language` (nullable, mysql + sqlite); null = Server-Default
- **UserApi/UserRepository**: `findLanguage()` / `updateLanguage()` als Direkt-Queries - die Praeferenz muss nicht durch die grosse `UserEntity` gefaedelt werden (geringeres Risiko)
- **Login-Hook**: beim Web-Login wird die gespeicherte Sprache in die frische Session uebernommen -> UI in der User-Sprache ueber Logins/Geraete hinweg
- **Switcher persistiert** die Wahl fuer eingeloggte User nach `user.language` (Gaeste weiterhin nur Session)

Damit ist der **Nav-Switcher die persistente pro-User-Einstellung** (ueberlebt neue Sessions). Eine zusaetzliche dedizierte Dropdown auf der Settings-Seite waere optionaler Politur-Zusatz.

## Verifikation
`findLanguage`/`updateLanguage` Round-Trip live OK; Switcher persistiert fuer authed User (Unit-Test), nicht fuer Gaeste; Migration sauber angewendet. Volle Suite gruen: 193 Tests / 446 Assertions, phpcs/phpstan/psalm clean.

## Naechste Etappe
Bulk-Uebersetzung der restlichen ~101 Templates in Abschnitten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)