### PR TITLE
feat(i18n): move DE/EN language switcher into profile settings

### DIFF
--- a/resources/translations/de.php
+++ b/resources/translations/de.php
@@ -697,6 +697,8 @@ return [
     'profile.email' => 'E-Mail-Adresse',
     'profile.email_hint' => 'Wird für Kontowiederherstellung und Benachrichtigungen verwendet.',
     'profile.image_requirements' => 'JPEG, PNG, GIF oder WebP. Max. 5 MB.',
+    'profile.language' => 'Sprache',
+    'profile.language_hint' => 'Bestimmt die Sprache der Oberfläche und wird in deinem Profil gespeichert.',
     'profile.loading_security' => 'Sicherheitseinstellungen werden geladen...',
     'profile.logout' => 'Abmelden',
     'profile.name_hint' => 'Nur Buchstaben und Zahlen, 2-24 Zeichen.',

--- a/resources/translations/en.php
+++ b/resources/translations/en.php
@@ -697,6 +697,8 @@ return [
     'profile.email' => 'Email Address',
     'profile.email_hint' => 'Used for account recovery and notifications.',
     'profile.image_requirements' => 'JPEG, PNG, GIF, or WebP. Max 5MB.',
+    'profile.language' => 'Language',
+    'profile.language_hint' => 'Sets the interface language and is saved to your profile.',
     'profile.loading_security' => 'Loading security settings...',
     'profile.logout' => 'Logout',
     'profile.name_hint' => 'Only letters and numbers, 2-24 characters.',

--- a/templates/partials/language_switcher.twig
+++ b/templates/partials/language_switcher.twig
@@ -1,4 +1,4 @@
 <div class="btn-group btn-group-sm" role="group" aria-label="{{ t('lang.label') }}">
-    <a href="{{ applicationUrl }}/language/de" class="btn btn-outline-light{% if locale() == 'de' %} active{% endif %}" title="{{ t('lang.german') }}">DE</a>
-    <a href="{{ applicationUrl }}/language/en" class="btn btn-outline-light{% if locale() == 'en' %} active{% endif %}" title="{{ t('lang.english') }}">EN</a>
+    <a href="{{ applicationUrl }}/language/de" class="btn btn-outline-secondary{% if locale() == 'de' %} active{% endif %}" title="{{ t('lang.german') }}">DE</a>
+    <a href="{{ applicationUrl }}/language/en" class="btn btn-outline-secondary{% if locale() == 'en' %} active{% endif %}" title="{{ t('lang.english') }}">EN</a>
 </div>

--- a/templates/partials/navbar_app.twig
+++ b/templates/partials/navbar_app.twig
@@ -22,9 +22,6 @@
 
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-center">
                 <li class="nav-item me-2">
-                    {% include 'partials/language_switcher.twig' %}
-                </li>
-                <li class="nav-item me-2">
                     <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
                         <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
                         <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>

--- a/templates/partials/navbar_public.twig
+++ b/templates/partials/navbar_public.twig
@@ -5,7 +5,6 @@
             <span>{{ applicationName ?? 'Pathary' }}</span>
         </a>
         <div class="d-flex align-items-center gap-3">
-            {% include 'partials/language_switcher.twig' %}
             <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
                 <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
                 <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>

--- a/templates/public/profile.twig
+++ b/templates/public/profile.twig
@@ -398,6 +398,14 @@
                     </div>
                 </form>
 
+                <div class="form-group">
+                    <label><i class="bi bi-translate"></i> {{ t('profile.language') }}</label>
+                    <div class="mt-1">
+                        {% include 'partials/language_switcher.twig' %}
+                    </div>
+                    <p class="form-hint">{{ t('profile.language_hint') }}</p>
+                </div>
+
                 <div class="logout-section">
                     <h3><i class="bi bi-box-arrow-right"></i> {{ t('profile.sign_out') }}</h3>
                     <p>{{ t('profile.sign_out_hint') }}</p>


### PR DESCRIPTION
Verschiebt den DE/EN-Slider aus der Nav in die **Profileinstellungen** (dein Wunsch) - dort gehoert er als persistente pro-User-Einstellung hin.

## Was drin ist
- Switcher aus `navbar_app` und `navbar_public` entfernt (Nav wird aufgeraeumt)
- "Sprache"-Einstellung (mit DE/EN-Switcher + Hinweis) im Profil-Tab ergaenzt
- Switcher-Styling von `btn-outline-light` auf `btn-outline-secondary` umgestellt, damit er im Profil in Light- und Dark-Theme lesbar ist (er sitzt nicht mehr in der immer-dunklen Navbar)

Die Wahl persistiert weiterhin nach `user.language` (via `GET /language/{locale}`, Etappe 2). Gaeste auf oeffentlichen Seiten nutzen jetzt die Default-Sprache (Deutsch); Umschalten ist eine eingeloggte, pro-User-Einstellung.

## Verifikation
Oeffentliche Nav zeigt live kein DE/EN mehr; alle Templates kompilieren; volle Suite gruen (193 Tests). +2 Katalog-Keys (profile.language*), jetzt 951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)