### PR TITLE
feat(profile): card-based profile settings redesign

### DIFF
--- a/resources/translations/de.php
+++ b/resources/translations/de.php
@@ -703,6 +703,7 @@ return [
     'profile.logout' => 'Abmelden',
     'profile.name_hint' => 'Nur Buchstaben und Zahlen, 2-24 Zeichen.',
     'profile.photo' => 'Profilfoto',
+    'profile.profile_card_subtitle' => 'Deine öffentliche Identität im Filmclub',
     'profile.remove' => 'Entfernen',
     'profile.save_changes' => 'Änderungen speichern',
     'profile.sign_out' => 'Abmelden',

--- a/resources/translations/en.php
+++ b/resources/translations/en.php
@@ -703,6 +703,7 @@ return [
     'profile.logout' => 'Logout',
     'profile.name_hint' => 'Only letters and numbers, 2-24 characters.',
     'profile.photo' => 'Profile Photo',
+    'profile.profile_card_subtitle' => 'Your public identity in the movie club',
     'profile.remove' => 'Remove',
     'profile.save_changes' => 'Save Changes',
     'profile.sign_out' => 'Sign Out',

--- a/templates/public/profile-security.twig
+++ b/templates/public/profile-security.twig
@@ -1,331 +1,421 @@
-<div class="profile-card">
+<div class="pds-security pds-stack">
     <style>
-        .security-section {
-            margin-bottom: 2rem;
-            padding-bottom: 2rem;
-            border-bottom: 1px solid var(--bs-border-color);
+        /* Security-tab fragment. Nests inside .pds-root, so it inherits all --pds-* tokens. */
+        .pds-security .pds-pad {
+            padding: 20px 24px;
         }
 
-        .security-section:last-child {
+        .pds-security .pds-flex-col-md {
+            display: flex;
+            flex-direction: column;
+            gap: var(--pds-s-md);
+        }
+
+        .pds-security .pds-title-row {
+            display: flex;
+            align-items: center;
+            gap: var(--pds-s-sm);
+        }
+
+        .pds-security .pds-badge {
+            font-family: var(--pds-font-mono);
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: .04em;
+            text-transform: uppercase;
+            color: #12140F;
+            background: var(--pds-gold);
+            border-radius: 999px;
+            padding: 3px 10px;
+        }
+
+        .pds-security .pds-badge-muted {
+            font-family: var(--pds-font-mono);
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            color: var(--pds-muted);
+            background: transparent;
+            border: 1px solid var(--pds-border);
+            border-radius: 999px;
+            padding: 3px 10px;
+        }
+
+        .pds-security .pds-desc {
+            font-size: 13px;
+            color: var(--pds-muted);
+            margin-top: 6px;
+            max-width: 520px;
+        }
+
+        .pds-security .pds-top-row {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: var(--pds-s-lg);
+        }
+
+        .pds-security .pds-divider-row {
+            border-top: 1px solid var(--pds-hair);
+            padding-top: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--pds-s-lg);
+            flex-wrap: wrap;
+        }
+
+        .pds-security .pds-meta {
+            font-size: 13px;
+            color: var(--pds-muted);
+        }
+
+        .pds-security .pds-mono {
+            font-family: var(--pds-font-mono);
+        }
+
+        .pds-security .pds-meta strong {
+            font-family: var(--pds-font-mono);
+            font-weight: 600;
+            color: var(--pds-text);
+        }
+
+        .pds-security .pds-card-head-row {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: var(--pds-s-md);
+        }
+
+        .pds-security .pds-link-danger {
+            background: none;
+            border: none;
+            color: var(--pds-danger);
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            padding: 0;
+        }
+
+        .pds-security .pds-link-danger:hover {
+            text-decoration: underline;
+        }
+
+        /* Trusted-device rows */
+        .pds-security .pds-dev-row {
+            padding: 14px 24px;
+            display: flex;
+            align-items: center;
+            gap: var(--pds-s-md);
+            border-bottom: 1px solid var(--pds-hair);
+        }
+
+        .pds-security .pds-dev-row:last-child {
             border-bottom: none;
-            margin-bottom: 0;
-            padding-bottom: 0;
         }
 
-        .security-section h3 {
-            font-size: 1.2rem;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
+        .pds-security .pds-dev-icon {
+            width: 36px;
+            height: 36px;
+            border-radius: var(--pds-r-sm);
+            background: var(--pds-surface-2);
+            border: 1px solid var(--pds-hair);
             display: flex;
             align-items: center;
-            gap: 0.5rem;
+            justify-content: center;
+            font-size: 16px;
+            color: var(--pds-muted);
+            flex-shrink: 0;
         }
 
-        .security-section h3 i {
-            font-size: 1.1rem;
+        .pds-security .pds-dev-body {
+            flex: 1;
+            min-width: 0;
         }
 
-        .security-section p {
-            color: var(--bs-secondary-color);
-            font-size: 0.9rem;
-            margin-bottom: 1rem;
+        .pds-security .pds-dev-name {
+            font-size: 14px;
+            font-weight: 600;
         }
 
-        .status-badge {
-            display: inline-flex;
+        .pds-security .pds-dev-meta {
+            font-size: 12px;
+            color: var(--pds-dim);
+            font-family: var(--pds-font-mono);
+            margin-top: 2px;
+        }
+
+        .pds-security .pds-dev-revoke {
+            font-size: 13px;
+            color: var(--pds-muted);
+            background: transparent;
+            border: 1px solid var(--pds-border);
+            border-radius: var(--pds-r-sm);
+            padding: 6px 14px;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+
+        .pds-security .pds-dev-revoke:hover {
+            border-color: var(--pds-danger);
+            color: var(--pds-danger);
+        }
+
+        .pds-security .pds-empty {
+            padding: 20px 24px;
+            font-size: 13px;
+            color: var(--pds-muted);
+        }
+
+        /* Security-activity rows */
+        .pds-security .pds-ev-row {
+            padding: 12px 24px;
+            display: flex;
             align-items: center;
-            gap: 0.5rem;
-            padding: 0.25rem 0.75rem;
-            border-radius: 20px;
-            font-size: 0.85rem;
+            gap: var(--pds-s-md);
+            border-bottom: 1px solid var(--pds-hair);
+        }
+
+        .pds-security .pds-ev-row:last-child {
+            border-bottom: none;
+        }
+
+        .pds-security .pds-ev-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--pds-dim);
+            flex-shrink: 0;
+        }
+
+        .pds-security .pds-ev-dot--success {
+            background: var(--pds-success);
+        }
+
+        .pds-security .pds-ev-dot--danger {
+            background: var(--pds-danger);
+        }
+
+        .pds-security .pds-ev-dot--gold {
+            background: var(--pds-gold);
+        }
+
+        .pds-security .pds-ev-label {
+            flex: 1;
+            font-size: 13px;
             font-weight: 500;
+            min-width: 0;
         }
 
-        .status-badge.enabled {
-            background: rgba(25, 135, 84, 0.1);
-            color: #198754;
+        .pds-security .pds-ev-ip {
+            font-family: var(--pds-font-mono);
+            font-size: 12px;
+            color: var(--pds-dim);
         }
 
-        .status-badge.disabled {
-            background: rgba(108, 117, 125, 0.1);
-            color: #6c757d;
+        .pds-security .pds-ev-time {
+            font-family: var(--pds-font-mono);
+            font-size: 12px;
+            color: var(--pds-dim);
+            text-align: right;
+            white-space: nowrap;
         }
 
-        .device-list {
-            list-style: none;
-            padding: 0;
-            margin: 1rem 0;
-        }
-
-        .device-item {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 1rem;
-            background: var(--bs-body-bg);
-            border: 1px solid var(--bs-border-color);
-            border-radius: 8px;
-            margin-bottom: 0.5rem;
-        }
-
-        .device-info h4 {
-            font-size: 1rem;
-            font-weight: 600;
-            margin: 0 0 0.25rem 0;
-        }
-
-        .device-info p {
-            font-size: 0.85rem;
-            color: var(--bs-secondary-color);
-            margin: 0;
-        }
-
-        .event-list {
-            list-style: none;
-            padding: 0;
-            margin: 1rem 0;
-        }
-
-        .event-item {
-            padding: 0.75rem;
-            background: var(--bs-body-bg);
-            border: 1px solid var(--bs-border-color);
-            border-radius: 8px;
-            margin-bottom: 0.5rem;
-        }
-
-        .event-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 0.25rem;
-        }
-
-        .event-type {
-            font-weight: 600;
-            font-size: 0.9rem;
-        }
-
-        .event-time {
-            font-size: 0.8rem;
-            color: var(--bs-secondary-color);
-        }
-
-        .event-details {
-            font-size: 0.85rem;
-            color: var(--bs-secondary-color);
-        }
-
-        /* Security Activity Collapse Styles */
-        .security-activity-container {
+        /* Collapse behaviour — class names kept for profile-security.js */
+        .pds-security .security-activity-container {
             position: relative;
         }
 
-        .security-activity-container.collapsed .event-list {
-            max-height: calc(5.5 * (0.75rem * 2 + 1rem + 0.5rem + 1px * 2)); /* ~5.5 items */
+        .pds-security .event-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .pds-security .security-activity-container.collapsed .event-list {
+            max-height: 300px;
             overflow: hidden;
         }
 
-        .security-activity-fade-overlay {
+        .pds-security .security-activity-fade-overlay {
             position: absolute;
             bottom: 0;
             left: 0;
             right: 0;
             height: 120px;
-            background: linear-gradient(to bottom, transparent 0%, var(--bs-body-bg) 80%);
+            background: linear-gradient(to bottom, transparent 0%, var(--pds-surface) 85%);
             pointer-events: none;
             display: flex;
             align-items: flex-end;
             justify-content: center;
-            padding-bottom: 1rem;
+            padding-bottom: 16px;
         }
 
-        .security-activity-container.expanded .security-activity-fade-overlay {
+        .pds-security .security-activity-container.expanded .security-activity-fade-overlay {
             display: none;
         }
 
-        .show-more-btn {
+        .pds-security .show-more-btn {
             pointer-events: auto;
-            background: var(--bs-body-bg);
-            border: 1px solid var(--bs-border-color);
-            color: var(--bs-body-color);
-            padding: 0.5rem 1.5rem;
-            border-radius: 20px;
-            font-size: 0.9rem;
-            font-weight: 500;
+            background: var(--pds-surface-2);
+            border: 1px solid var(--pds-border);
+            color: var(--pds-text);
+            padding: 7px 16px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 600;
             cursor: pointer;
             display: flex;
             align-items: center;
-            gap: 0.5rem;
-            transition: all 0.2s;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            gap: 0.4rem;
+            transition: border-color .15s, background .15s;
         }
 
-        .show-more-btn:hover {
-            background: var(--bs-secondary-bg);
-            border-color: var(--bs-primary);
-            transform: translateY(-1px);
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        .pds-security .show-more-btn:hover {
+            border-color: var(--pds-gold);
         }
 
-        .show-more-btn:focus {
-            outline: 2px solid var(--bs-primary);
-            outline-offset: 2px;
-        }
-
-        .show-more-btn i {
+        .pds-security .show-more-btn i {
             transition: transform 0.2s;
         }
 
-        .security-activity-container.expanded .show-more-btn i {
+        .pds-security .security-activity-container.expanded .show-more-btn i {
             transform: rotate(180deg);
         }
     </style>
 
-    <!-- Password Section -->
-    <div class="security-section">
-        <h3><i class="bi bi-key"></i> {{ t('security.password') }}</h3>
-        <p>{{ t('security.password_hint') }}</p>
-        <button type="button" class="btn btn-primary" id="changePasswordBtn">
-            <i class="bi bi-key"></i> {{ t('security.change_password') }}
-        </button>
+    <!-- Password card -->
+    <div class="pds-card">
+        <div class="pds-card-head">
+            <div class="pds-card-title">{{ t('security.password') }}</div>
+            <div class="pds-card-sub">{{ t('security.password_hint') }}</div>
+        </div>
+        <div class="pds-card-foot">
+            <button type="button" class="pds-btn pds-btn-primary" id="changePasswordBtn">
+                <i class="bi bi-key"></i> {{ t('security.change_password') }}
+            </button>
+        </div>
     </div>
 
-    <!-- Two-Factor Authentication Section -->
-    <div class="security-section">
-        <h3><i class="bi {% if totpEnabled %}bi-lock-fill{% else %}bi-unlock-fill{% endif %}"></i> {{ t('security.two_factor') }}</h3>
-        <p>{{ t('security.two_factor_hint') }}</p>
+    <!-- Two-factor authentication card -->
+    <div class="pds-card pds-pad pds-flex-col-md">
+        <div class="pds-top-row">
+            <div>
+                <div class="pds-title-row">
+                    <span class="pds-card-title">{{ t('security.two_factor') }}</span>
+                    {% if totpEnabled %}
+                        <span class="pds-badge">{{ t('security.enabled') }}</span>
+                    {% else %}
+                        <span class="pds-badge-muted">{{ t('security.disabled') }}</span>
+                    {% endif %}
+                </div>
+                <div class="pds-desc">{{ t('security.two_factor_hint') }}</div>
+            </div>
+            {% if totpEnabled %}
+                <button type="button" class="pds-btn pds-btn-ghost" id="reconfigure2FABtn">
+                    <i class="bi bi-phone"></i> {{ t('security.setup_new_device') }}
+                </button>
+            {% else %}
+                <button type="button" class="pds-btn pds-btn-primary" id="enable2FABtn">
+                    <i class="bi bi-shield-plus"></i> {{ t('security.enable_2fa') }}
+                </button>
+            {% endif %}
+        </div>
 
         {% if totpEnabled %}
-            <div class="d-flex justify-content-between align-items-center mb-3">
-                <span class="status-badge enabled">
-                    <i class="bi bi-check-circle-fill"></i> {{ t('security.enabled') }}
-                </span>
-                <span class="text-body-secondary small">
-                    <i class="bi bi-shield-lock-fill"></i> {{ t('security.required_cannot_disable') }}
-                </span>
-            </div>
-            <button type="button" class="btn btn-sm btn-outline-primary" id="reconfigure2FABtn">
-                <i class="bi bi-phone"></i> {{ t('security.setup_new_device') }}
-            </button>
-        {% else %}
-            <div class="d-flex justify-content-between align-items-center mb-3">
-                <span class="status-badge disabled">
-                    <i class="bi bi-circle"></i> {{ t('security.disabled') }}
-                </span>
-                <button type="button" class="btn btn-primary" id="enable2FABtn">
-                    <i class="bi bi-shield-plus"></i> {{ t('security.enable_2fa') }}
+            <div class="pds-divider-row">
+                <div class="pds-meta"><strong>{{ recoveryCodesCount }}</strong> {{ t('security.unused_codes') }}</div>
+                <button type="button" class="pds-btn pds-btn-ghost" id="regenerateCodesBtn">
+                    <i class="bi bi-arrow-clockwise"></i> {{ t('security.regenerate_codes') }}
                 </button>
             </div>
         {% endif %}
     </div>
 
-    <!-- Recovery Codes Section -->
+    <!-- Trusted devices card -->
     {% if totpEnabled %}
-        <div class="security-section">
-            <h3><i class="bi bi-life-preserver"></i> {{ t('security.recovery_codes') }}</h3>
-            <p>{{ t('security.recovery_codes_hint') }}</p>
-            <div class="d-flex justify-content-between align-items-center">
-                <span class="text-muted">{{ recoveryCodesCount }} {{ t('security.unused_codes') }}</span>
-                <button type="button" class="btn btn-outline-primary" id="regenerateCodesBtn">
-                    <i class="bi bi-arrow-clockwise"></i> {{ t('security.regenerate_codes') }}
-                </button>
+        <div class="pds-card">
+            <div class="pds-card-head pds-card-head-row">
+                <div>
+                    <div class="pds-card-title">{{ t('security.trusted_devices') }}</div>
+                    <div class="pds-card-sub">{{ t('security.trusted_devices_hint') }}</div>
+                </div>
+                {% if trustedDevices is not empty %}
+                    <button type="button" class="pds-link-danger" id="revokeAllDevicesBtn">
+                        {{ t('security.revoke_all') }}
+                    </button>
+                {% endif %}
             </div>
-        </div>
-    {% endif %}
-
-    <!-- Trusted Devices Section -->
-    {% if totpEnabled %}
-        <div class="security-section">
-            <h3><i class="bi bi-laptop"></i> {{ t('security.trusted_devices') }}</h3>
-            <p>{{ t('security.trusted_devices_hint') }}</p>
 
             {% if trustedDevices is not empty %}
-                <ul class="device-list">
-                    {% for device in trustedDevices %}
-                        <li class="device-item">
-                            <div class="device-info">
-                                <h4><i class="bi bi-laptop"></i> {{ device.deviceName }}</h4>
-                                <p>
-                                    {{ t('security.added') }} {{ device.createdAt|date('Y-m-d H:i') }}
-                                    {% if device.lastUsedAt %}
-                                        | {{ t('security.last_used') }} {{ device.lastUsedAt|date('Y-m-d H:i') }}
-                                    {% endif %}
-                                    | {{ t('security.expires') }} {{ device.expiresAt|date('Y-m-d H:i') }}
-                                </p>
+                {% for device in trustedDevices %}
+                    <div class="pds-dev-row">
+                        <div class="pds-dev-icon"><i class="bi bi-laptop"></i></div>
+                        <div class="pds-dev-body">
+                            <div class="pds-dev-name">{{ device.deviceName }}</div>
+                            <div class="pds-dev-meta">
+                                {{ t('security.added') }} {{ device.createdAt|date('Y-m-d H:i') }}
+                                {% if device.lastUsedAt %}
+                                    &middot; {{ t('security.last_used') }} {{ device.lastUsedAt|date('Y-m-d H:i') }}
+                                {% endif %}
+                                &middot; {{ t('security.expires') }} {{ device.expiresAt|date('Y-m-d H:i') }}
                             </div>
-                            <button type="button" class="btn btn-sm btn-outline-danger revoke-device-btn" data-device-id="{{ device.id }}">
-                                <i class="bi bi-x-circle"></i> {{ t('security.revoke') }}
-                            </button>
-                        </li>
-                    {% endfor %}
-                </ul>
-                <div class="mt-3">
-                    <button type="button" class="btn btn-outline-danger" id="revokeAllDevicesBtn">
-                        <i class="bi bi-x-circle"></i> {{ t('security.revoke_all') }}
-                    </button>
-                </div>
+                        </div>
+                        <button type="button" class="pds-dev-revoke revoke-device-btn" data-device-id="{{ device.id }}">
+                            {{ t('security.revoke') }}
+                        </button>
+                    </div>
+                {% endfor %}
             {% else %}
-                <div class="alert alert-info">
-                    <i class="bi bi-info-circle"></i>
-                    <strong>{{ t('security.no_trusted_devices') }}</strong>
-                    <p class="mb-0 mt-2">{{ t('security.trust_device_hint') }}</p>
+                <div class="pds-empty">
+                    <strong>{{ t('security.no_trusted_devices') }}</strong><br>
+                    {{ t('security.trust_device_hint') }}
                 </div>
             {% endif %}
         </div>
     {% endif %}
 
-    <!-- Security Activity Log Section -->
-    <div class="security-section">
-        <h3><i class="bi bi-activity"></i> {{ t('security.security_activity') }}</h3>
-        <p>{{ t('security.security_activity_hint') }}</p>
+    <!-- Security activity card -->
+    <div class="pds-card">
+        <div class="pds-card-head">
+            <div class="pds-card-title">{{ t('security.security_activity') }}</div>
+            <div class="pds-card-sub">{{ t('security.security_activity_hint') }}</div>
+        </div>
 
         {% if securityEvents is not empty %}
             <div class="security-activity-container{% if securityEvents|length > 5 %} collapsed{% endif %}" id="securityActivityContainer">
                 <ul class="event-list" id="securityEventList">
                     {% for event in securityEvents %}
-                        <li class="event-item">
-                            <div class="event-header">
-                                <span class="event-type">
-                                    {% if event.event_type == 'totp_enabled' %}
-                                        <i class="bi bi-shield-plus"></i>
-                                    {% elseif event.event_type == 'totp_disabled' %}
-                                        <i class="bi bi-shield-x"></i>
-                                    {% elseif event.event_type == 'password_changed' %}
-                                        <i class="bi bi-key"></i>
-                                    {% elseif event.event_type == 'login_success' %}
-                                        <i class="bi bi-box-arrow-in-right"></i>
-                                    {% elseif event.event_type starts with 'login_failed' %}
-                                        <i class="bi bi-exclamation-triangle"></i>
-                                    {% else %}
-                                        <i class="bi bi-info-circle"></i>
-                                    {% endif %}
-                                    {% if event.event_type == 'totp_enabled' %}{{ t('security.event_totp_enabled') }}
-                                    {% elseif event.event_type == 'totp_disabled' %}{{ t('security.event_totp_disabled') }}
-                                    {% elseif event.event_type == 'password_changed' %}{{ t('security.event_password_changed') }}
-                                    {% elseif event.event_type == 'recovery_codes_generated' %}{{ t('security.event_recovery_generated') }}
-                                    {% elseif event.event_type == 'recovery_code_used' %}{{ t('security.event_recovery_used') }}
-                                    {% elseif event.event_type == 'trusted_device_added' %}{{ t('security.event_device_added') }}
-                                    {% elseif event.event_type == 'trusted_device_removed' %}{{ t('security.event_device_removed') }}
-                                    {% elseif event.event_type == 'login_success' %}{{ t('security.event_login_success') }}
-                                    {% elseif event.event_type == 'login_failed_password' %}{{ t('security.event_login_failed_password') }}
-                                    {% elseif event.event_type == 'login_failed_totp' %}{{ t('security.event_login_failed_totp') }}
-                                    {% elseif event.event_type == 'logout' %}{{ t('security.event_logout') }}
-                                    {% else %}{{ event.event_type }}
-                                    {% endif %}
-                                </span>
-                                <span class="event-time">{{ event.created_at }}</span>
-                            </div>
-                            {% if event.ip_address or event.user_agent %}
-                                <div class="event-details">
-                                    {% if event.ip_address %}
-                                        {{ t('security.ip') }} {{ event.ip_address }}
-                                    {% endif %}
-                                    {% if event.user_agent %}
-                                        | {{ event.user_agent|slice(0, 60) }}{% if event.user_agent|length > 60 %}...{% endif %}
-                                    {% endif %}
-                                </div>
+                        {% if event.event_type in ['login_success', 'totp_enabled', 'trusted_device_added', 'recovery_codes_generated', 'recovery_code_used'] %}
+                            {% set evTone = 'success' %}
+                        {% elseif event.event_type == 'totp_disabled' or event.event_type == 'trusted_device_removed' or event.event_type starts with 'login_failed' %}
+                            {% set evTone = 'danger' %}
+                        {% elseif event.event_type == 'password_changed' %}
+                            {% set evTone = 'gold' %}
+                        {% else %}
+                            {% set evTone = 'neutral' %}
+                        {% endif %}
+                        <li class="pds-ev-row">
+                            <span class="pds-ev-dot pds-ev-dot--{{ evTone }}"></span>
+                            <span class="pds-ev-label">
+                                {% if event.event_type == 'totp_enabled' %}{{ t('security.event_totp_enabled') }}
+                                {% elseif event.event_type == 'totp_disabled' %}{{ t('security.event_totp_disabled') }}
+                                {% elseif event.event_type == 'password_changed' %}{{ t('security.event_password_changed') }}
+                                {% elseif event.event_type == 'recovery_codes_generated' %}{{ t('security.event_recovery_generated') }}
+                                {% elseif event.event_type == 'recovery_code_used' %}{{ t('security.event_recovery_used') }}
+                                {% elseif event.event_type == 'trusted_device_added' %}{{ t('security.event_device_added') }}
+                                {% elseif event.event_type == 'trusted_device_removed' %}{{ t('security.event_device_removed') }}
+                                {% elseif event.event_type == 'login_success' %}{{ t('security.event_login_success') }}
+                                {% elseif event.event_type == 'login_failed_password' %}{{ t('security.event_login_failed_password') }}
+                                {% elseif event.event_type == 'login_failed_totp' %}{{ t('security.event_login_failed_totp') }}
+                                {% elseif event.event_type == 'logout' %}{{ t('security.event_logout') }}
+                                {% else %}{{ event.event_type }}
+                                {% endif %}
+                            </span>
+                            {% if event.ip_address %}
+                                <span class="pds-ev-ip">{{ event.ip_address }}</span>
                             {% endif %}
+                            <span class="pds-ev-time">{{ event.created_at }}</span>
                         </li>
                     {% endfor %}
                 </ul>
@@ -339,7 +429,7 @@
                 {% endif %}
             </div>
         {% else %}
-            <p class="text-muted">{{ t('security.no_events') }}</p>
+            <div class="pds-empty">{{ t('security.no_events') }}</div>
         {% endif %}
     </div>
 </div>

--- a/templates/public/profile.twig
+++ b/templates/public/profile.twig
@@ -4,326 +4,452 @@
 
 {% block stylesheets %}
 <style>
-    .profile-header {
-        margin-bottom: 2rem;
+    /* ===== Profile design system tokens (--pds-*), scoped to .pds-root =====
+       Default block = dark (app default). Light overrides below via [data-bs-theme].
+       Shared verbatim with the security-tab fragment which nests inside .pds-root. */
+    .pds-root {
+        --pds-gold: #FBBC09;
+        --pds-bg: #15171B;
+        --pds-surface: #1C1F24;
+        --pds-surface-2: #22262C;
+        --pds-border: #2A2E35;
+        --pds-hair: rgba(255, 255, 255, .06);
+        --pds-text: #F2F3F5;
+        --pds-muted: #A9B0BA;
+        --pds-dim: #7A828C;
+        --pds-nav: #101216;
+        --pds-danger: #E5654B;
+        --pds-success: #4FB477;
+        --pds-r: 14px;
+        --pds-r-sm: 8px;
+        --pds-s-sm: 8px;
+        --pds-s-md: 16px;
+        --pds-s-lg: 24px;
+        --pds-font: "Geist", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        --pds-font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
 
-    /* Bootstrap Tabs Styling */
-    .nav-tabs {
-        border-bottom: 2px solid var(--bs-border-color);
-        margin-bottom: 2rem;
+    [data-bs-theme="light"] .pds-root {
+        --pds-bg: #FFFFFF;
+        --pds-surface: #FBFBFC;
+        --pds-surface-2: #F5F6F8;
+        --pds-border: #E3E6EA;
+        --pds-hair: #EEF0F3;
+        --pds-text: #15171B;
+        --pds-muted: #5B636E;
+        --pds-dim: #8A9099;
+        --pds-nav: #101216;
+        --pds-danger: #C0392B;
+        --pds-success: #198754;
     }
 
-    .nav-tabs .nav-link {
-        color: var(--bs-secondary-color);
+    .pds-root {
+        color: var(--pds-text);
+        font-family: var(--pds-font);
+    }
+
+    .pds-wrap {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 8px 24px 40px;
+        box-sizing: border-box;
+    }
+
+    /* Identity header */
+    .pds-identity {
+        display: flex;
+        align-items: center;
+        gap: var(--pds-s-md);
+        margin-bottom: 36px;
+    }
+
+    .pds-avatar-lg,
+    .pds-avatar-lg img {
+        width: 72px;
+        height: 72px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+
+    .pds-avatar-lg {
+        background: var(--pds-surface);
+        border: 3px solid var(--pds-gold);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 30px;
+        font-weight: 700;
+        color: var(--pds-gold);
+        overflow: hidden;
+    }
+
+    .pds-avatar-lg img {
+        object-fit: cover;
+    }
+
+    .pds-name {
+        margin: 0;
+        font-size: 26px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .pds-identity-sub {
+        font-size: 14px;
+        color: var(--pds-muted);
+        margin-top: 4px;
+    }
+
+    /* Tabs (Bootstrap-driven; only restyled) */
+    .pds-tabs {
+        display: flex;
+        gap: var(--pds-s-lg);
+        border-bottom: 1px solid var(--pds-border);
+        margin-bottom: 28px;
+        padding: 0;
+        list-style: none;
+    }
+
+    .pds-tabs .nav-item {
+        margin-bottom: -1px;
+    }
+
+    .pds-tabs .nav-link {
+        background: transparent;
         border: none;
         border-bottom: 2px solid transparent;
-        padding: 1rem 0.75rem;
+        color: var(--pds-muted);
         font-weight: 500;
-        transition: all 0.2s;
+        font-size: 15px;
+        padding: 10px 2px 12px;
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        cursor: pointer;
+        transition: color .15s, border-color .15s;
     }
 
-    /* Hide filled icons by default, show on active */
-    .nav-tabs .nav-link .icon-filled {
+    .pds-tabs .nav-link .icon-filled {
         display: none;
     }
 
-    .nav-tabs .nav-link.active .icon-filled {
+    .pds-tabs .nav-link.active .icon-filled {
         display: inline-block;
     }
 
-    .nav-tabs .nav-link.active .icon-outline {
+    .pds-tabs .nav-link.active .icon-outline {
         display: none;
     }
 
-    .nav-tabs .nav-link:hover {
-        color: var(--pathe-yellow);
-        border-bottom-color: var(--pathe-yellow);
+    .pds-tabs .nav-link:hover {
+        color: var(--pds-text);
     }
 
-    .nav-tabs .nav-link.active {
-        color: var(--pathe-yellow);
-        background: transparent;
-        border-bottom-color: var(--pathe-yellow);
+    .pds-tabs .nav-link.active {
+        color: var(--pds-text);
+        font-weight: 600;
+        border-bottom-color: var(--pds-gold);
     }
 
-    .profile-card {
-        background: var(--bs-tertiary-bg);
-        border-radius: 12px;
-        padding: 2rem;
-        max-width: 800px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    /* Keep the header and tabs aligned with the centered card. */
-    .profile-header,
-    #profileTabs {
-        max-width: 800px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    .profile-image-section {
+    /* Card primitives */
+    .pds-stack {
         display: flex;
         flex-direction: column;
-        align-items: center;
-        margin-bottom: 2rem;
-        padding-bottom: 2rem;
-        border-bottom: 1px solid var(--bs-border-color);
+        gap: var(--pds-s-lg);
     }
 
-    .profile-image-section h3 {
-        font-size: 1.2rem;
+    .pds-card {
+        background: var(--pds-surface);
+        border: 1px solid var(--pds-border);
+        border-radius: var(--pds-r);
+        overflow: hidden;
+    }
+
+    .pds-card-head {
+        padding: 20px 24px;
+        border-bottom: 1px solid var(--pds-hair);
+    }
+
+    .pds-card-title {
+        font-size: 15px;
         font-weight: 600;
-        margin-bottom: 1.5rem;
+    }
+
+    .pds-card-sub {
+        font-size: 13px;
+        color: var(--pds-muted);
+        margin-top: 2px;
+    }
+
+    .pds-card-body {
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: var(--pds-s-lg);
+    }
+
+    .pds-card-foot {
+        padding: 16px 24px;
+        border-top: 1px solid var(--pds-hair);
+        display: flex;
+        justify-content: flex-end;
+        background: var(--pds-surface-2);
+    }
+
+    /* Single-row card (language, sign out) */
+    .pds-row-card {
+        background: var(--pds-surface);
+        border: 1px solid var(--pds-border);
+        border-radius: var(--pds-r);
+        padding: 20px 24px;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        justify-content: space-between;
+        gap: var(--pds-s-lg);
     }
 
-    .profile-image-section h3 i {
-        font-size: 1.1rem;
+    .pds-row-label {
+        font-size: 15px;
+        font-weight: 600;
     }
 
-    .profile-image-container {
-        position: relative;
-        width: 150px;
-        height: 150px;
-        margin-bottom: 1rem;
+    .pds-row-sub {
+        font-size: 13px;
+        color: var(--pds-muted);
+        margin-top: 2px;
     }
 
-    .profile-image {
-        width: 150px;
-        height: 150px;
+    /* Photo row */
+    .pds-photo-row {
+        display: flex;
+        align-items: center;
+        gap: var(--pds-s-lg);
+    }
+
+    .pds-avatar,
+    .pds-avatar img {
+        width: 88px;
+        height: 88px;
         border-radius: 50%;
-        object-fit: cover;
-        border: 4px solid var(--pathe-yellow);
+        flex-shrink: 0;
     }
 
-    .profile-image-placeholder {
-        width: 150px;
-        height: 150px;
-        border-radius: 50%;
-        background: linear-gradient(135deg, var(--pathe-dark) 0%, #3a3a3a 100%);
+    .pds-avatar {
+        background: var(--pds-surface-2);
+        border: 3px solid var(--pds-gold);
         display: flex;
         align-items: center;
         justify-content: center;
-        color: var(--pathe-yellow);
-        font-size: 3rem;
+        font-size: 36px;
         font-weight: 700;
-        border: 4px solid var(--pathe-yellow);
+        color: var(--pds-gold);
+        overflow: hidden;
     }
 
-    .profile-image-actions {
+    .pds-avatar img {
+        object-fit: cover;
+    }
+
+    .pds-photo-actions {
         display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        justify-content: center;
+        flex-direction: column;
+        gap: var(--pds-s-sm);
+        align-items: flex-start;
     }
 
-    .btn-upload {
+    .pds-photo-buttons {
+        display: flex;
+        gap: var(--pds-s-sm);
+        flex-wrap: wrap;
+    }
+
+    /* Fields */
+    .pds-grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--pds-s-lg);
+    }
+
+    .pds-field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .pds-field-label {
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .pds-input {
+        width: 100%;
+        font-size: 14px;
+        color: var(--pds-text);
+        background: var(--pds-bg);
+        border: 1px solid var(--pds-border);
+        border-radius: var(--pds-r-sm);
+        padding: 10px 12px;
+        outline: none;
+        font-family: inherit;
+        box-sizing: border-box;
+        transition: border-color .15s, box-shadow .15s;
+    }
+
+    .pds-input:focus {
+        border-color: var(--pds-gold);
+        box-shadow: 0 0 0 3px rgba(251, 188, 9, .15);
+    }
+
+    .pds-field-hint {
+        font-size: 12px;
+        color: var(--pds-dim);
+    }
+
+    /* Buttons */
+    .pds-btn {
+        font-size: 13px;
+        font-weight: 600;
+        border-radius: var(--pds-r-sm);
+        padding: 8px 16px;
+        cursor: pointer;
+        border: 1px solid transparent;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+        line-height: 1.2;
+        transition: background .15s, border-color .15s, color .15s;
+        white-space: nowrap;
+    }
+
+    .pds-btn-primary {
+        background: var(--pds-gold);
+        color: #12140F;
+    }
+
+    .pds-btn-primary:hover {
+        background: #e0a808;
+    }
+
+    .pds-btn-ghost {
+        background: transparent;
+        border-color: var(--pds-border);
+        color: var(--pds-muted);
+    }
+
+    .pds-btn-ghost:hover {
+        border-color: var(--pds-dim);
+        color: var(--pds-text);
+    }
+
+    .pds-btn-danger {
+        background: transparent;
+        border-color: var(--pds-danger);
+        color: var(--pds-danger);
+    }
+
+    .pds-btn-danger:hover {
+        background: rgba(192, 57, 43, .08);
+    }
+
+    /* Upload button wraps a hidden file input */
+    .pds-upload {
         position: relative;
         overflow: hidden;
-        background: var(--pathe-yellow);
-        border-color: var(--pathe-yellow);
-        color: var(--pathe-dark);
-        font-weight: 600;
     }
 
-    .btn-upload:hover {
-        background: #e0a808;
-        border-color: #e0a808;
-        color: var(--pathe-dark);
-    }
-
-    .btn-upload input[type="file"] {
+    .pds-upload input[type="file"] {
         position: absolute;
-        top: 0;
-        left: 0;
+        inset: 0;
         width: 100%;
         height: 100%;
         opacity: 0;
         cursor: pointer;
     }
 
-    .btn-remove-image {
-        background: transparent;
-        border: 1px solid var(--bs-border-color);
-        color: var(--bs-secondary-color);
-    }
-
-    .btn-remove-image:hover {
-        background: rgba(220, 53, 69, 0.1);
-        border-color: #dc3545;
-        color: #dc3545;
-    }
-
-    .image-requirements {
-        font-size: 0.8rem;
-        color: var(--bs-secondary-color);
-        text-align: center;
-        margin-top: 0.5rem;
-    }
-
-    .form-group {
-        margin-bottom: 1.5rem;
-    }
-
-    .form-group label {
+    /* Language segmented control (reuses partials/language_switcher.twig markup) */
+    .pds-seg .btn-group {
         display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-weight: 500;
-        margin-bottom: 0.5rem;
+        border: 1px solid var(--pds-border);
+        border-radius: var(--pds-r-sm);
+        overflow: hidden;
+        flex-shrink: 0;
     }
 
-    .form-group label i {
-        font-size: 0.95rem;
-    }
-
-    .form-group input {
-        width: 100%;
-        padding: 0.75rem;
-        border: 1px solid var(--bs-border-color);
-        border-radius: 8px;
-        background: var(--bs-body-bg);
-        color: var(--bs-body-color);
-        font-size: 1rem;
-    }
-
-    .form-group input:focus {
-        outline: none;
-        border-color: var(--accent-purple);
-        box-shadow: 0 0 0 3px rgba(111, 45, 189, 0.1);
-    }
-
-    .form-group .form-hint {
-        font-size: 0.8rem;
-        color: var(--bs-secondary-color);
-        margin-top: 0.25rem;
-    }
-
-    .form-actions {
-        display: flex;
-        gap: 1rem;
-        padding-top: 1rem;
-        border-top: 1px solid var(--bs-border-color);
-    }
-
-    .btn-save {
-        background: var(--pathe-yellow);
-        border-color: var(--pathe-yellow);
-        color: var(--pathe-dark);
+    .pds-seg .btn-group .btn {
+        border: none;
+        border-radius: 0;
+        background: var(--pds-surface-2);
+        color: var(--pds-muted);
+        font-size: 13px;
         font-weight: 600;
-        padding: 0.75rem 2rem;
+        padding: 7px 16px;
+        box-shadow: none;
     }
 
-    .btn-save:hover {
-        background: #e0a808;
-        border-color: #e0a808;
-        color: var(--pathe-dark);
+    .pds-seg .btn-group .btn.active {
+        background: var(--pds-gold);
+        color: #12140F;
     }
 
-    .alert {
-        padding: 1rem;
-        border-radius: 8px;
-        margin-bottom: 1.5rem;
+    /* Alerts */
+    .pds-alert {
+        padding: 12px 16px;
+        border-radius: var(--pds-r-sm);
+        margin-bottom: var(--pds-s-lg);
+        font-size: 14px;
+        border: 1px solid transparent;
     }
 
-    .alert-success {
-        background: rgba(25, 135, 84, 0.1);
-        border: 1px solid rgba(25, 135, 84, 0.3);
-        color: #198754;
+    .pds-alert-success {
+        background: rgba(79, 180, 119, .12);
+        border-color: rgba(79, 180, 119, .35);
+        color: var(--pds-success);
     }
 
-    .alert-danger {
-        background: rgba(220, 53, 69, 0.1);
-        border: 1px solid rgba(220, 53, 69, 0.3);
-        color: #dc3545;
+    .pds-alert-danger {
+        background: rgba(229, 101, 75, .12);
+        border-color: rgba(229, 101, 75, .35);
+        color: var(--pds-danger);
     }
 
-    .logout-section,
-    .language-section {
-        margin-top: 2rem;
-        padding-top: 2rem;
-        border-top: 1px solid var(--bs-border-color);
-    }
-
-    .logout-section h3,
-    .language-section h3 {
-        font-size: 1.1rem;
-        font-weight: 600;
-        margin-bottom: 0.5rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-    }
-
-    .logout-section h3 i,
-    .language-section h3 i {
-        font-size: 1rem;
-    }
-
-    .logout-section p,
-    .language-section p {
-        color: var(--bs-secondary-color);
-        font-size: 0.9rem;
-        margin-bottom: 1rem;
-    }
-
-    .language-section .language-toggle {
-        margin-bottom: 0.75rem;
-    }
-
-    .btn-logout {
-        background: transparent;
-        border: 1px solid #dc3545;
-        color: #dc3545;
-        font-weight: 600;
-        padding: 0.5rem 1.5rem;
-    }
-
-    .btn-logout:hover {
-        background: #dc3545;
-        color: #fff;
-    }
-
-    @media (max-width: 576px) {
-        .profile-card {
-            padding: 1.5rem;
+    @media (max-width: 640px) {
+        .pds-wrap {
+            padding: 8px 16px 40px;
         }
 
-        .profile-image-container {
-            width: 120px;
-            height: 120px;
+        .pds-grid-2 {
+            grid-template-columns: 1fr;
         }
 
-        .profile-image,
-        .profile-image-placeholder {
-            width: 120px;
-            height: 120px;
-        }
-
-        .profile-image-placeholder {
-            font-size: 2.5rem;
+        .pds-photo-row {
+            flex-direction: column;
+            align-items: flex-start;
         }
     }
 </style>
 {% endblock %}
 
 {% block body %}
-<div class="container mt-4">
-    <!-- Page Header -->
-    <div class="profile-header mb-4">
-        <h1 class="h3"><i class="bi bi-person-circle me-2"></i>{{ t('profile.title') }}</h1>
-        <p class="text-muted">{{ t('profile.subtitle') }}</p>
+<div class="pds-root">
+  <div class="pds-wrap">
+    <!-- Identity header -->
+    <div class="pds-identity">
+        <div class="pds-avatar-lg">
+            {% if profileImage %}
+                <img src="{{ applicationUrl }}/profile-images/{{ profileImage }}" alt="{{ userName }}">
+            {% else %}
+                {{ userName|first|upper }}
+            {% endif %}
+        </div>
+        <div class="pds-identity-meta">
+            <h1 class="pds-name">{{ userName }}</h1>
+            <div class="pds-identity-sub">{{ userEmail }}</div>
+        </div>
     </div>
 
-    <ul class="nav nav-tabs" id="profileTabs" role="tablist">
+    <!-- Tabs -->
+    <ul class="nav pds-tabs" id="profileTabs" role="tablist">
         <li class="nav-item" role="presentation">
             <button class="nav-link active" id="profile-tab" data-bs-toggle="tab" data-bs-target="#profile" type="button" role="tab" aria-controls="profile" aria-selected="true">
                 <i class="bi bi-person icon-outline" aria-hidden="true"></i>
@@ -343,81 +469,93 @@
     <div class="tab-content" id="profileTabsContent">
         <!-- Profile Tab -->
         <div class="tab-pane fade show active" id="profile" role="tabpanel" aria-labelledby="profile-tab">
-            <div class="profile-card">
+            <div class="pds-stack">
                 {% if success %}
-                    <div class="alert alert-success">
+                    <div class="pds-alert pds-alert-success">
                         <i class="bi bi-check-circle"></i> {{ success }}
                     </div>
                 {% endif %}
 
                 {% if error %}
-                    <div class="alert alert-danger">
+                    <div class="pds-alert pds-alert-danger">
                         <i class="bi bi-exclamation-circle"></i> {{ error }}
                     </div>
                 {% endif %}
 
-                <form action="{{ applicationUrl }}/profile" method="post" enctype="multipart/form-data" id="profileForm">
-                    <div class="profile-image-section">
-                        <h3><i class="bi bi-person-circle"></i> {{ t('profile.photo') }}</h3>
-                        <div class="profile-image-container">
-                            {% if profileImage %}
-                                <img src="{{ applicationUrl }}/profile-images/{{ profileImage }}" alt="{{ userName }}" class="profile-image" id="profileImagePreview">
-                            {% else %}
-                                <div class="profile-image-placeholder" id="profileImagePlaceholder">
-                                    {{ userName|first|upper }}
+                <!-- Profile card -->
+                <form action="{{ applicationUrl }}/profile" method="post" enctype="multipart/form-data" id="profileForm" class="pds-card">
+                    <div class="pds-card-head">
+                        <div class="pds-card-title">{{ t('profile.tab_profile') }}</div>
+                        <div class="pds-card-sub">{{ t('profile.profile_card_subtitle') }}</div>
+                    </div>
+                    <div class="pds-card-body">
+                        <div class="pds-photo-row">
+                            <div class="pds-avatar">
+                                {% if profileImage %}
+                                    <img src="{{ applicationUrl }}/profile-images/{{ profileImage }}" alt="{{ userName }}" id="profileImagePreview">
+                                {% else %}
+                                    <span id="profileImagePlaceholder">{{ userName|first|upper }}</span>
+                                    <img src="" alt="" id="profileImagePreview" style="display: none;">
+                                {% endif %}
+                            </div>
+                            <div class="pds-photo-actions">
+                                <div class="pds-photo-buttons">
+                                    <label class="pds-btn pds-btn-primary pds-upload">
+                                        <i class="bi bi-camera"></i> {{ t('profile.upload_photo') }}
+                                        <input type="file" name="profile_image" accept="image/jpeg,image/png,image/gif,image/webp" id="profileImageInput">
+                                    </label>
+                                    {% if profileImage %}
+                                        <button type="button" class="pds-btn pds-btn-ghost" id="removeImageBtn">
+                                            <i class="bi bi-trash"></i> {{ t('profile.remove') }}
+                                        </button>
+                                    {% endif %}
                                 </div>
-                                <img src="" alt="" class="profile-image" id="profileImagePreview" style="display: none;">
-                            {% endif %}
+                                <div class="pds-field-hint">{{ t('profile.image_requirements') }}</div>
+                            </div>
                         </div>
 
-                        <div class="profile-image-actions">
-                            <label class="btn btn-upload">
-                                <i class="bi bi-camera"></i> {{ t('profile.upload_photo') }}
-                                <input type="file" name="profile_image" accept="image/jpeg,image/png,image/gif,image/webp" id="profileImageInput">
+                        <div class="pds-grid-2">
+                            <label class="pds-field" for="name">
+                                <span class="pds-field-label">{{ t('profile.display_name') }}</span>
+                                <input class="pds-input" type="text" id="name" name="name" value="{{ userName }}" required pattern="[a-zA-Z0-9]+" minlength="2" maxlength="24">
+                                <span class="pds-field-hint">{{ t('profile.name_hint') }}</span>
                             </label>
-                            {% if profileImage %}
-                                <button type="button" class="btn btn-remove-image" id="removeImageBtn">
-                                    <i class="bi bi-trash"></i> {{ t('profile.remove') }}
-                                </button>
-                            {% endif %}
+                            <label class="pds-field" for="email">
+                                <span class="pds-field-label">{{ t('profile.email') }}</span>
+                                <input class="pds-input" type="email" id="email" name="email" value="{{ userEmail }}">
+                                <span class="pds-field-hint">{{ t('profile.email_hint') }}</span>
+                            </label>
                         </div>
-                        <p class="image-requirements">{{ t('profile.image_requirements') }}</p>
-                        <input type="hidden" name="remove_image" id="removeImageFlag" value="0">
                     </div>
 
-                    <div class="form-group">
-                        <label for="name"><i class="bi bi-person-badge"></i> {{ t('profile.display_name') }}</label>
-                        <input type="text" id="name" name="name" value="{{ userName }}" required pattern="[a-zA-Z0-9]+" minlength="2" maxlength="24">
-                        <p class="form-hint">{{ t('profile.name_hint') }}</p>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="email"><i class="bi bi-envelope"></i> {{ t('profile.email') }}</label>
-                        <input type="email" id="email" name="email" value="{{ userEmail }}">
-                        <p class="form-hint">{{ t('profile.email_hint') }}</p>
-                    </div>
-
+                    <input type="hidden" name="remove_image" id="removeImageFlag" value="0">
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
 
-                    <div class="form-actions">
-                        <button type="submit" class="btn btn-save">
+                    <div class="pds-card-foot">
+                        <button type="submit" class="pds-btn pds-btn-primary">
                             <i class="bi bi-check-lg"></i> {{ t('profile.save_changes') }}
                         </button>
                     </div>
                 </form>
 
-                <div class="language-section">
-                    <h3><i class="bi bi-translate"></i> {{ t('profile.language') }}</h3>
-                    <div class="language-toggle">
+                <!-- Language card -->
+                <div class="pds-row-card">
+                    <div>
+                        <div class="pds-row-label">{{ t('profile.language') }}</div>
+                        <div class="pds-row-sub">{{ t('profile.language_hint') }}</div>
+                    </div>
+                    <div class="pds-seg">
                         {% include 'partials/language_switcher.twig' %}
                     </div>
-                    <p>{{ t('profile.language_hint') }}</p>
                 </div>
 
-                <div class="logout-section">
-                    <h3><i class="bi bi-box-arrow-right"></i> {{ t('profile.sign_out') }}</h3>
-                    <p>{{ t('profile.sign_out_hint') }}</p>
-                    <button type="button" class="btn btn-logout" onclick="logoutAndRedirect()">
+                <!-- Sign out card -->
+                <div class="pds-row-card">
+                    <div>
+                        <div class="pds-row-label">{{ t('profile.sign_out') }}</div>
+                        <div class="pds-row-sub">{{ t('profile.sign_out_hint') }}</div>
+                    </div>
+                    <button type="button" class="pds-btn pds-btn-danger" onclick="logoutAndRedirect()">
                         <i class="bi bi-box-arrow-right"></i> {{ t('profile.logout') }}
                     </button>
                 </div>
@@ -430,11 +568,12 @@
                 {% if securityTabContent is defined %}
                     {{ securityTabContent|raw }}
                 {% else %}
-                    <p class="text-center"><i class="bi bi-hourglass-split"></i> {{ t('profile.loading_security') }}</p>
+                    <p class="text-center pds-card-sub"><i class="bi bi-hourglass-split"></i> {{ t('profile.loading_security') }}</p>
                 {% endif %}
             </div>
         </div>
     </div>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Setzt das Design-Handoff "Profile Settings Redesign" um: Card-basiertes Layout der Profil-Einstellungsseite.

## Umsetzung
- **Identity-Header** (Avatar mit Gold-Rand + Name + E-Mail) ueber den Tabs
- **Profile-Tab:** Profile-Card (Foto + Name/E-Mail-Grid + Save-Footer), Language-Card (DE/EN-Toggle), Sign-out-Card
- **Security-Tab:** Password-, 2FA+Recovery-, Trusted-Devices- und Security-Activity-Cards
- Eigenes `--pds-*`-Token-Set (Light + Dark, gemappt auf die App-Palette: Gold #FBBC09, neutrale Graustufen)

## Reines Restyling - volle Verdrahtung erhalten
Profil-Formular + Foto-Upload-Hooks, Bootstrap-Tabs + Security-Tab-AJAX-Loader, und jeder profile-security.js-Hook (changePassword/reconfigure2FA/enable2FA/regenerate/revoke/security-activity). Passwort-Aendern bleibt ein Modal (kein erfundenes Inline-Formular). i18n via `t()`, ein neuer Key, Schweizer Rechtschreibung.

## Verifikation
Beide Templates kompilieren, Kataloge valide (null Eszett), alle Wiring-Hooks vorhanden (grep-bestaetigt), volle Suite gruen (193 Tests). **Visuell noch nicht live geprueft** (Profilseite ist auth-gated) - bitte anschauen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)