### PR TITLE
feat(ui): sun/moon icon inside the theme toggle knob

### DIFF
--- a/public/assets/css/theme.css
+++ b/public/assets/css/theme.css
@@ -135,3 +135,81 @@ code, kbd, pre, samp, .font-monospace {
     height: 20px;
     font-size: 0.9rem;
 }
+
+/* -----------------------------------------------------------------------------
+   Theme toggle: sun/moon icon inside the sliding knob (replaces the switch +
+   separate emoji). The hidden #darkModeToggle checkbox still drives theme.js;
+   the visual state follows its :checked state (checked = dark).
+   -------------------------------------------------------------------------- */
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    margin: 0;
+}
+
+.theme-toggle__input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.theme-toggle__track {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    width: 52px;
+    height: 28px;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.18);
+    transition: background 0.2s ease;
+}
+
+.theme-toggle__knob {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #FBBC09;
+    color: #101216;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.72rem;
+    transform: translateX(24px); /* light (default): knob on the right */
+    transition: transform 0.2s ease;
+}
+
+.theme-toggle__icon {
+    line-height: 1;
+}
+
+.theme-toggle__icon--moon {
+    display: none;
+}
+
+/* checked == dark theme */
+.theme-toggle__input:checked ~ .theme-toggle__track {
+    background: rgba(255, 255, 255, 0.22);
+}
+
+.theme-toggle__input:checked ~ .theme-toggle__track .theme-toggle__knob {
+    transform: translateX(0); /* dark: knob on the left */
+}
+
+.theme-toggle__input:checked ~ .theme-toggle__track .theme-toggle__icon--sun {
+    display: none;
+}
+
+.theme-toggle__input:checked ~ .theme-toggle__track .theme-toggle__icon--moon {
+    display: inline;
+}
+
+.theme-toggle__input:focus-visible ~ .theme-toggle__track {
+    outline: 2px solid #FBBC09;
+    outline-offset: 2px;
+}

--- a/templates/partials/navbar_app.twig
+++ b/templates/partials/navbar_app.twig
@@ -22,11 +22,15 @@
 
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-center">
                 <li class="nav-item me-2">
-                    <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
-                        <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
-                        <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>
-                        <span id="themeIcon" style="font-size: 1.1rem;">🌙</span>
-                    </div>
+                    <label class="theme-toggle" title="{{ t('nav.toggle_dark_mode') }}">
+                        <input class="theme-toggle__input" type="checkbox" role="switch" id="darkModeToggle" aria-label="{{ t('nav.dark_mode') }}">
+                        <span class="theme-toggle__track">
+                            <span class="theme-toggle__knob">
+                                <i class="bi bi-moon-stars-fill theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true"></i>
+                                <i class="bi bi-sun-fill theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true"></i>
+                            </span>
+                        </span>
+                    </label>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="{{ applicationUrl }}/movies">{{ t('nav.all_movies') }}</a>

--- a/templates/partials/navbar_public.twig
+++ b/templates/partials/navbar_public.twig
@@ -5,11 +5,15 @@
             <span>{{ applicationName ?? 'Pathary' }}</span>
         </a>
         <div class="d-flex align-items-center gap-3">
-            <div class="form-check form-switch mb-0" title="{{ t('nav.toggle_dark_mode') }}">
-                <input class="form-check-input" type="checkbox" role="switch" id="darkModeToggle" style="cursor: pointer;">
-                <label class="form-check-label visually-hidden" for="darkModeToggle">{{ t('nav.dark_mode') }}</label>
-                <span id="themeIcon" style="font-size: 1.1rem;">🌙</span>
-            </div>
+            <label class="theme-toggle" title="{{ t('nav.toggle_dark_mode') }}">
+                <input class="theme-toggle__input" type="checkbox" role="switch" id="darkModeToggle" aria-label="{{ t('nav.dark_mode') }}">
+                <span class="theme-toggle__track">
+                    <span class="theme-toggle__knob">
+                        <i class="bi bi-moon-stars-fill theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true"></i>
+                        <i class="bi bi-sun-fill theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true"></i>
+                    </span>
+                </span>
+            </label>
             <a href="{{ applicationUrl }}/login" class="btn btn-warning" style="background-color: var(--pathe-yellow); border-color: var(--pathe-yellow); color: var(--pathe-dark);">
                 {{ t('nav.login') }}
             </a>


### PR DESCRIPTION
Kleiner visueller Wunsch: die Sonne/Mond im Slider-Knopf statt Emoji daneben.

- Custom-Toggle: der gleitende Knopf traegt das Icon - **Mond im Dark-Mode, Sonne im Light-Mode** (Bootstrap Icons, goldener Knopf)
- Versteckte `#darkModeToggle`-Checkbox bleibt -> `theme.js` unveraendert; Knopf-Position + Icon-Wechsel rein per CSS ueber `:checked`
- In beiden Navbars

Beide Navbars kompilieren, Checkbox-ID erhalten, oeffentliche Nav rendert den Toggle live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)