### PR TITLE
fix(release): tag releases as v* so the versioned Docker build triggers

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "pathary",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,


### PR DESCRIPTION
release-please tagged 0.7.1 as `pathary-v0.7.1`, but `docker-image.yml` only fires on `v*` tags (and 0.7.0 was `v0.7.0`). Der versionierte GHCR-Build ist deshalb für die Release nicht angesprungen — nur der `:latest`-Build vom main-Push.

`include-component-in-tag: false` entfernt die `pathary-`-Komponente → künftige Tags sind `v0.7.2` etc., passend zum Docker-Trigger und zur 0.7.0-Konvention.

Für die aktuelle 0.7.1 habe ich den Tag `v0.7.1` bereits manuell nachgezogen, damit das versionierte Image gebaut wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)