### PR TITLE
fix(ui): stale theme.css cache (toggle), i18n-broken security tab loader, profile spacing

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -340,6 +340,9 @@ class Factory
 
         $twig->addGlobal('applicationUrl', $applicationUrl);
         $twig->addGlobal('applicationName', $container->get(ServerSettings::class)->getApplicationName() ?? 'Pathary');
+        // Cache-busting token for static assets: changes with each release so browsers
+        // never serve a stale theme.css / theme.js after an upgrade.
+        $twig->addGlobal('assetVersion', $container->get(ServerSettings::class)->getApplicationVersion() ?? 'dev');
         $twig->addGlobal('applicationTimezone', $container->get(ServerSettings::class)->getApplicationTimezone() ?? DateTime::DEFAULT_TIME_ZONE);
         $twig->addGlobal('currentUserName', $user?->getName());
         $twig->addGlobal('currentUserIsAdmin', $user?->isAdmin());

--- a/templates/layouts/app_base.twig
+++ b/templates/layouts/app_base.twig
@@ -21,10 +21,10 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
     <!-- Global CSS -->
-    <link rel="stylesheet" href="{{ applicationUrl }}/css/global.css">
+    <link rel="stylesheet" href="{{ applicationUrl }}/css/global.css?v={{ assetVersion }}">
 
     <!-- Custom Theme CSS -->
-    <link rel="stylesheet" href="{{ applicationUrl }}/assets/css/theme.css">
+    <link rel="stylesheet" href="{{ applicationUrl }}/assets/css/theme.css?v={{ assetVersion }}">
 
     {% block stylesheets %}{% endblock %}
 </head>
@@ -57,10 +57,10 @@
     <script src="{{ applicationUrl }}/js/bootstrap.bundle.min.js"></script>
 
     <!-- Custom Components JS -->
-    <script src="{{ applicationUrl }}/assets/js/popcorn.js"></script>
+    <script src="{{ applicationUrl }}/assets/js/popcorn.js?v={{ assetVersion }}"></script>
 
     <!-- Theme Toggle JS -->
-    <script src="{{ applicationUrl }}/assets/js/theme.js"></script>
+    <script src="{{ applicationUrl }}/assets/js/theme.js?v={{ assetVersion }}"></script>
 
     <!-- Background Health Check (Admin Only) -->
     {% if currentUser is defined and currentUser is not null and currentUser.isAdmin() %}

--- a/templates/layouts/public_base.twig
+++ b/templates/layouts/public_base.twig
@@ -20,8 +20,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
     <!-- Custom Theme CSS -->
-    <link rel="stylesheet" href="{{ applicationUrl }}/assets/css/theme.css">
-    <link rel="stylesheet" href="{{ applicationUrl }}/css/global.css">
+    <link rel="stylesheet" href="{{ applicationUrl }}/assets/css/theme.css?v={{ assetVersion }}">
+    <link rel="stylesheet" href="{{ applicationUrl }}/css/global.css?v={{ assetVersion }}">
 
     {% block stylesheets %}{% endblock %}
 </head>
@@ -46,7 +46,7 @@
     <script src="{{ applicationUrl }}/js/bootstrap.bundle.min.js"></script>
 
     <!-- Theme Toggle JS -->
-    <script src="{{ applicationUrl }}/assets/js/theme.js"></script>
+    <script src="{{ applicationUrl }}/assets/js/theme.js?v={{ assetVersion }}"></script>
 
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/public/profile.twig
+++ b/templates/public/profile.twig
@@ -51,7 +51,7 @@
     .pds-wrap {
         max-width: 860px;
         margin: 0 auto;
-        padding: 8px 24px 40px;
+        padding: 32px 24px 40px;
         box-sizing: border-box;
     }
 
@@ -568,7 +568,7 @@
                 {% if securityTabContent is defined %}
                     {{ securityTabContent|raw }}
                 {% else %}
-                    <p class="text-center pds-card-sub"><i class="bi bi-hourglass-split"></i> {{ t('profile.loading_security') }}</p>
+                    <p class="text-center pds-card-sub" data-loading-placeholder><i class="bi bi-hourglass-split"></i> {{ t('profile.loading_security') }}</p>
                 {% endif %}
             </div>
         </div>
@@ -674,7 +674,7 @@ document.addEventListener('DOMContentLoaded', function() {
             history.pushState({tab: 'security'}, '', '{{ applicationUrl }}/profile/security');
 
             const content = document.getElementById('securityTabContent');
-            if (content && content.innerHTML.includes('Loading security settings')) {
+            if (content && content.querySelector('[data-loading-placeholder]')) {
                 loadSecurityTab();
             }
         });
@@ -707,7 +707,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // If content is pre-rendered (not "Loading..."), initialize listeners immediately
         const content = document.getElementById('securityTabContent');
-        if (content && !content.innerHTML.includes('Loading security settings')) {
+        if (content && !content.querySelector('[data-loading-placeholder]')) {
             if (typeof initializeSecurityListeners === 'function') {
                 initializeSecurityListeners();
             }


### PR DESCRIPTION
Drei gemeldete Bugs auf Profil-/Detailseite:

## 1. Dark-Mode-Toggle unstyled nach Navigation
Das Toggle-Markup wurde in #61 zusammen mit `theme.css` geaendert, aber die Asset-Links hatten **kein Cache-Busting** → der Browser lieferte die alte `theme.css` von vor #61 (neues Markup, alte CSS = roher Checkbox). Fix: `assetVersion`-Twig-Global (App-Version) + `?v={{ assetVersion }}` an den custom css/js-Links in beiden Base-Layouts. Jede Release bricht den Cache.

## 2. Sicherheit-Tab haengt bei „wird geladen"
Der Loader prüfte `innerHTML.includes(Loading security settings)` — ein **hartkodierter englischer String**. Mit deutscher UI matchte der Check nie → `loadSecurityTab()` wurde nie aufgerufen. Fix: sprachunabhaengiger `[data-loading-placeholder]`-Marker statt Text-Check (2 Stellen).

## 3. Profil-Header zu nah an der Navbar
`.pds-wrap` padding-top 8px → 32px.

Volle Suite gruen (193 Tests), Templates kompilieren, Asset-Links geben jetzt `?v=` aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)