### PR TITLE
ci: build the versioned GHCR image on release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,17 @@ on:
       - 'OPEN_ISSUES.md'
       - 'security_audit_report.txt'
   workflow_dispatch:
+  # Called by release-please.yml after a release is cut. The tag that
+  # release-please pushes with GITHUB_TOKEN cannot trigger this workflow on its
+  # own (GitHub suppresses workflow runs for GITHUB_TOKEN-created events), so the
+  # release job invokes it here and passes the version tag explicitly.
+  workflow_call:
+    inputs:
+      version:
+        description: 'Explicit image tag to publish (e.g. v0.7.2)'
+        required: false
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -62,7 +73,7 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ inputs.version || github.ref_name }}
 
   validate-migrations:
     name: Validate Migrations
@@ -184,6 +195,8 @@ jobs:
             type=ref,event=branch
             # Tag name (v1.0.0, v0.1.0-alpha.1, etc.)
             type=ref,event=tag
+            # Explicit version when called from release-please (workflow_call)
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             # Short SHA
             type=sha,prefix=sha-
 
@@ -201,7 +214,7 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ inputs.version || github.ref_name }}
 
       - name: Summary
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,12 @@ name: release-please
 
 # Maintains a rolling "release PR" on main: release-please reads the conventional
 # commit messages (feat/fix/BREAKING), computes the next version and updates the
-# changelog. Merging that PR creates the git tag + GitHub release, which in turn
-# triggers docker-image.yml to build and publish the versioned GHCR image.
+# changelog. Merging that PR creates the git tag + GitHub release. release-please
+# signs that tag with GITHUB_TOKEN, and GitHub does not start new workflow runs
+# for GITHUB_TOKEN-created events, so the tag push cannot trigger docker-image.yml
+# by itself. Instead the publish-release-image job below calls docker-image.yml
+# directly (workflow_call) and passes the version, so the versioned GHCR image is
+# always built when a release is cut.
 on:
   push:
     branches:
@@ -16,9 +20,26 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Build and push the versioned GHCR image (e.g. v0.7.2) right after a release
+  # is created. Reuses docker-image.yml so the build/validate/push logic stays in
+  # one place.
+  publish-release-image:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Problem

`release-please` tags releases with `GITHUB_TOKEN`. GitHub suppresses new workflow runs for `GITHUB_TOKEN`-created events, so the `v*` tag push never triggered `docker-image.yml` — the `:vX.Y.Z` image was never built. v0.7.2 had to be built manually via `workflow_dispatch`.

## Fix

- `docker-image.yml` is now callable via `workflow_call` with an optional `version` input, added as an explicit image tag (`type=raw`).
- `release-please.yml` exposes `release_created` / `tag_name` outputs and a new `publish-release-image` job that calls `docker-image.yml` with the version when a release is cut.

No new PAT/secret required — the build runs inside the already-legitimately-triggered workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)