### PR TITLE
fix(sync): scheduled cron sync ran against an empty SQLite DB

### DIFF
--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -31,4 +31,13 @@ echo "INFO: Generating symbolic link for storage"
 
 echo "INFO: Cron daemon will be started by supervisord (daily sync at 2:00 AM)"
 
+# Snapshot the container environment so the cron scheduled sync can restore it.
+# cron scrubs the environment before running a job; without this the sync would
+# fall back to SQLite and never touch the real database (see run-scheduled-sync.sh).
+if [ -f /app/build/scripts/write-cron-env.sh ]; then
+  /bin/bash /app/build/scripts/write-cron-env.sh /app/storage/.cron-env || echo "WARNING: could not persist cron environment"
+  # dev cron runs as the 'application' user, so make the snapshot readable by it.
+  chown application:application /app/storage/.cron-env 2>/dev/null || true
+fi
+
 exec "$@"

--- a/build/scripts/run-scheduled-sync.sh
+++ b/build/scripts/run-scheduled-sync.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 # Wrapper script for cron-based scheduled sync
-# Exports environment variables from container to cron context
+# Restores the container's runtime environment (cron scrubs it) and runs the sync
 
 set -e  # Exit on error
 set -u  # Exit on undefined variable
 
-# Export required environment variables (set by Docker Compose)
-export TMDB_API_KEY="${TMDB_API_KEY:-}"
-export DATABASE_MODE="${DATABASE_MODE:-sqlite}"
-export DATABASE_MYSQL_HOST="${DATABASE_MYSQL_HOST:-}"
-export DATABASE_MYSQL_PORT="${DATABASE_MYSQL_PORT:-3306}"
-export DATABASE_MYSQL_NAME="${DATABASE_MYSQL_NAME:-}"
-export DATABASE_MYSQL_USER="${DATABASE_MYSQL_USER:-}"
-export DATABASE_MYSQL_PASSWORD="${DATABASE_MYSQL_PASSWORD:-}"
-export APPLICATION_URL="${APPLICATION_URL:-http://localhost}"
-export TZ="${TZ:-UTC}"
-
-# Optional: OMDb API key for IMDb + Rotten Tomatoes ratings
-export OMDB_API_KEY="${OMDB_API_KEY:-}"
-
-# Optional: Image caching setting
-export TMDB_ENABLE_IMAGE_CACHING="${TMDB_ENABLE_IMAGE_CACHING:-0}"
+# cron runs jobs with an empty environment, so the container's runtime variables
+# (DB credentials, TMDB/OMDb keys, ENCRYPTION_KEY) are NOT available here. The
+# entrypoint snapshotted them to this file at container start; source it so the
+# sync talks to the real database instead of silently falling back to SQLite.
+# (The previous `export VAR="${VAR:-default}"` block was a no-op under cron: it
+# read from the already-empty environment and exported empty/default values.)
+CRON_ENV_FILE="${CRON_ENV_FILE:-/app/storage/.cron-env}"
+if [ -f "$CRON_ENV_FILE" ]; then
+    set -a  # auto-export everything sourced below
+    # shellcheck disable=SC1090
+    . "$CRON_ENV_FILE"
+    set +a
+else
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $CRON_ENV_FILE missing; refusing to run with an incomplete environment (would sync the wrong database)" >&2
+    exit 1
+fi
 
 # Change to app directory
 cd /app

--- a/build/scripts/test-cron-env.sh
+++ b/build/scripts/test-cron-env.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# =============================================================================
+# Regression test: cron scheduled-sync environment propagation
+# =============================================================================
+# Reproduces the bug where the nightly sync ran with cron's scrubbed environment,
+# fell back to SQLite (DATABASE_MODE unset) and never touched the real MySQL DB,
+# so IMDb / Rotten Tomatoes ratings were never synced.
+#
+# It writes the env snapshot, then runs a shell with a scrubbed environment
+# (env -i, exactly what cron does) and asserts the runtime variables are
+# restored intact — including values with '!' and '=' which naive quoting drops.
+#
+# Fails without the fix (no write-cron-env.sh / no sourcing). Passes with it.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+# Synthetic runtime environment (NOT real credentials). The password and key
+# deliberately contain '!' and '=' so the test proves %q quoting survives them.
+export DATABASE_MODE="mysql"
+export DATABASE_MYSQL_HOST="db.internal.example"
+export DATABASE_MYSQL_PASSWORD='dummy-P@ss!word=42'  # special chars must survive
+export TMDB_API_KEY="tmdb-test-key"
+export OMDB_API_KEY="omdb-test-key"
+export ENCRYPTION_KEY="dGVzdC1lbmNyeXB0aW9uLWtleQ=="  # fake base64; was missing from the old allowlist
+
+bash "$DIR/write-cron-env.sh" "$TMP" >/dev/null
+
+# Simulate cron: scrubbed environment, then source the snapshot like the wrapper does.
+result=$(env -i HOME=/root PATH=/usr/bin:/bin SHELL=/bin/sh /bin/bash -c "
+    set -a; . '$TMP'; set +a
+    printf '%s|%s|%s|%s|%s|%s' \
+        \"\${DATABASE_MODE:-UNSET}\" \
+        \"\${DATABASE_MYSQL_HOST:-UNSET}\" \
+        \"\${DATABASE_MYSQL_PASSWORD:-UNSET}\" \
+        \"\${TMDB_API_KEY:-UNSET}\" \
+        \"\${OMDB_API_KEY:-UNSET}\" \
+        \"\${ENCRYPTION_KEY:-UNSET}\"
+")
+
+expected="mysql|db.internal.example|dummy-P@ss!word=42|tmdb-test-key|omdb-test-key|dGVzdC1lbmNyeXB0aW9uLWtleQ=="
+
+if [ "$result" = "$expected" ]; then
+    echo "PASS: cron-scrubbed shell restored the full runtime environment"
+    exit 0
+fi
+
+echo "FAIL: environment not restored under cron simulation"
+echo "  expected: $expected"
+echo "  actual:   $result"
+exit 1

--- a/build/scripts/write-cron-env.sh
+++ b/build/scripts/write-cron-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# =============================================================================
+# Persist the container's runtime environment for cron
+# =============================================================================
+# cron runs every job with a scrubbed environment (only HOME/PATH/SHELL/LOGNAME
+# plus anything set inside the crontab). None of the container's runtime
+# variables that were passed via `docker run -e` (DB credentials, TMDB/OMDb API
+# keys, ENCRYPTION_KEY, ...) reach the scheduled sync. Without them the sync
+# falls back to the SQLite default (DATABASE_MODE unset) and never touches the
+# real database, so IMDb / Rotten Tomatoes ratings are never updated.
+#
+# The entrypoint calls this at container start to snapshot the environment into
+# a shell-sourceable file; run-scheduled-sync.sh sources it before invoking the
+# console command. We dump *every* exported variable (not a hand-maintained
+# allowlist, which previously drifted and forgot ENCRYPTION_KEY) with %q quoting
+# so values containing spaces, quotes or '!' survive re-sourcing intact.
+set -euo pipefail
+
+ENV_FILE="${1:-/app/storage/.cron-env}"
+
+umask 077
+: > "$ENV_FILE"
+
+var=""
+for var in $(compgen -e); do
+    # Skip shell-managed noise that must not leak into the cron shell.
+    case "$var" in
+        PWD|OLDPWD|SHLVL|_|HOME|HOSTNAME|TERM|PATH|SHELL|LOGNAME|USER) continue ;;
+    esac
+    printf '%s=%q\n' "$var" "${!var}" >> "$ENV_FILE"
+done
+
+echo "[CRON] Persisted $(wc -l < "$ENV_FILE" | tr -d ' ') runtime variables to $ENV_FILE"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -162,6 +162,15 @@ setup_symlinks() {
 start_cron() {
     echo "[CRON] Starting cron daemon for scheduled syncs..."
 
+    # Snapshot the container environment for the cron job. cron scrubs the
+    # environment before running a job, so without this the scheduled sync would
+    # not see DATABASE_MYSQL_*, TMDB_API_KEY, OMDB_API_KEY or ENCRYPTION_KEY and
+    # would fall back to an empty SQLite database (see run-scheduled-sync.sh).
+    if [ -f "/app/build/scripts/write-cron-env.sh" ]; then
+        /bin/bash /app/build/scripts/write-cron-env.sh /app/storage/.cron-env || \
+            echo "[CRON] WARNING: could not persist cron environment"
+    fi
+
     # Start cron in the background
     cron
 


### PR DESCRIPTION
## Symptom

IMDb + Rotten Tomatoes ratings never appear on movie detail pages (only TMDB). The nightly `sync:scheduled` cron job silently does nothing to the real data. (Priora c85c17cd)

## Root cause

cron runs every job with a **scrubbed environment** (only `HOME`/`PATH`/`SHELL`/`LOGNAME`). `run-scheduled-sync.sh` tried to propagate config with an `export VAR` default-expansion, but under cron those vars are unset — so it exported **empty** values and `DATABASE_MODE` fell back to `sqlite`. The sync ran against an **empty SQLite DB** instead of the production MySQL, touching no real movies. `ENCRYPTION_KEY` wasn't even in the list.

Reproduced with `env -i` (exactly cron's environment): `DATABASE_MODE` resolves to `sqlite`, all keys empty.

## Fix

- `build/scripts/write-cron-env.sh` — snapshots **every** exported var (drift-proof) with `%q` quoting so special chars survive re-sourcing.
- `docker/entrypoint.sh` (prod) + `build/scripts/entrypoint.sh` (dev) write the snapshot to `/app/storage/.cron-env` before cron starts.
- `run-scheduled-sync.sh` sources it, and now **fails loudly** if it's missing instead of silently syncing the wrong DB.
- `build/scripts/test-cron-env.sh` — regression test via `env -i` (synthetic credentials only).

## Verification

- Regression test passes; old approach reproduces `DATABASE_MODE=sqlite`.
- In-container `env -i` simulation now restores `DATABASE_MODE=mysql` + all vars.
- 193 PHP tests green.

## Note

Fixes the cron path. If IMDb/RT still don't populate after deploy, verify the OMDb API key is configured and movies carry an `imdb_id`:
```
docker exec -it Pathary php bin/console.php sync:scheduled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)