### PR TITLE
fix(sync): cron used a hardcoded /usr/bin/php absent from the prod image

### DIFF
--- a/build/scripts/run-scheduled-sync.sh
+++ b/build/scripts/run-scheduled-sync.sh
@@ -25,12 +25,23 @@ fi
 # Change to app directory
 cd /app
 
+# Resolve the PHP binary portably. cron's default PATH is /usr/bin:/bin, which
+# excludes /usr/local/bin where the php:8.x-apache (Debian) production image
+# installs php; the alpine dev image puts it in /usr/bin. Hardcoding either path
+# breaks the other, so extend PATH to cover both and resolve via command -v.
+export PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:${PATH:-}"
+PHP_BIN="$(command -v php || true)"
+if [ -z "$PHP_BIN" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: php binary not found on PATH ($PATH)" >&2
+    exit 127
+fi
+
 # Log start to stdout (captured by Docker logs)
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting scheduled sync (TMDB + OMDb)"
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting scheduled sync (TMDB + OMDb) using $PHP_BIN"
 
 # Run the sync command
 # Output goes to both file log (via >>) and stdout (via tee)
-/usr/bin/php bin/console.php sync:scheduled 2>&1 | tee -a storage/logs/scheduled-sync.log
+"$PHP_BIN" bin/console.php sync:scheduled 2>&1 | tee -a storage/logs/scheduled-sync.log
 
 # Capture exit code
 EXIT_CODE=${PIPESTATUS[0]}

--- a/build/scripts/test-cron-env.sh
+++ b/build/scripts/test-cron-env.sh
@@ -26,6 +26,19 @@ export TMDB_API_KEY="tmdb-test-key"
 export OMDB_API_KEY="omdb-test-key"
 export ENCRYPTION_KEY="dGVzdC1lbmNyeXB0aW9uLWtleQ=="  # fake base64; was missing from the old allowlist
 
+# Guard against the hardcoded PHP path regression: the php:8.x-apache production
+# image has php at /usr/local/bin/php, not /usr/bin/php, so the wrapper must
+# resolve it via command -v, never hardcode /usr/bin/php.
+WRAPPER="$DIR/run-scheduled-sync.sh"
+if grep -qE '(^|[^-])/usr/bin/php\b' "$WRAPPER"; then
+    echo "FAIL: run-scheduled-sync.sh hardcodes /usr/bin/php (breaks the Debian prod image)"
+    exit 1
+fi
+if ! grep -q 'command -v php' "$WRAPPER"; then
+    echo "FAIL: run-scheduled-sync.sh does not resolve php via 'command -v php'"
+    exit 1
+fi
+
 bash "$DIR/write-cron-env.sh" "$TMP" >/dev/null
 
 # Simulate cron: scrubbed environment, then source the snapshot like the wrapper does.


### PR DESCRIPTION
## Follow-up to the cron env fix (v0.7.3)

After fixing the scrubbed-environment bug, running the cron path on v0.7.3 surfaced a **second** bug:

```
/app/build/scripts/run-scheduled-sync.sh: line 33: /usr/bin/php: No such file or directory
ERROR: Scheduled sync failed with exit code 127
```

The wrapper hardcoded `/usr/bin/php`, which only exists in the **alpine dev** image. The **production** image (`php:8.4-apache`, Debian) installs php at `/usr/local/bin/php`, so every nightly cron run died with exit 127 before the sync started. Manual `docker exec ... php ...` worked because it resolved php via PATH, hiding the wrapper bug.

## Fix

Extend PATH to include `/usr/local/bin` (cron's default PATH `/usr/bin:/bin` excludes it) and resolve php via `command -v php` — works on both images. Regression test guards against re-hardcoding `/usr/bin/php`.

## Verification

In `php:8.4-apache` (= prod): old `/usr/bin/php` → not found; fix resolves `/usr/local/bin/php`, runs PHP 8.4.23. Regression test + 193 PHP tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)