### PR TITLE
chore(security): detect ghs_/gho_/ghu_ tokens incl. the new stateless format

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,10 +39,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # TEMPORARY: diagnosing "result is_error:true" after 1 turn. The action
-          # suppresses the SDK output by default, so the actual error message never
-          # reaches the log. Remove this flag once the cause is known.
-          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # TEMPORARY: diagnosing "result is_error:true" after 1 turn. The action
+          # suppresses the SDK output by default, so the actual error message never
+          # reaches the log. Remove this flag once the cause is known.
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/docs/security/SECRET-SCANNING.md
+++ b/docs/security/SECRET-SCANNING.md
@@ -105,7 +105,7 @@ The scanner looks for these patterns:
 |---------|-------------|---------|
 | `TMDB_API_KEY` | TMDB API keys | `TMDB_API_KEY="abc123..."` |
 | `API_KEY` | Generic API keys | `API_KEY="longkey123"` |
-| `GITHUB_TOKEN` | GitHub tokens | `ghp_xxxx` or `github_pat_xxxx` |
+| `GITHUB_TOKEN` | GitHub tokens | `ghp_xxxx`, `github_pat_xxxx`, `ghs_/gho_/ghu_xxxx` |
 | `AWS_KEY` | AWS access keys | `AKIA...` |
 | `PRIVATE_KEY` | SSH/TLS keys | `BEGIN PRIVATE KEY` |
 | `PASSWORD_HARDCODED` | Hardcoded passwords | `PASSWORD="secret123"` |

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -15,6 +15,7 @@
 #   - Added --self-test mode for verification
 #   - Improved output redaction for CI safety
 #   - Made compatible with bash 3.2+ (macOS default)
+#   - Added ghs_/gho_/ghu_ token detection incl. the new stateless JWT format
 #
 # Usage:
 #   ./scripts/secret-scan.sh [--verbose] [--self-test]
@@ -41,6 +42,12 @@ VERBOSE=0
 SELF_TEST=0
 FINDINGS=0
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# GitHub token formats, shared by the self-test and the main scan.
+# ghs_ (app installation), gho_ (OAuth) and ghu_ (user-to-server) tokens moved to a
+# stateless JWT format in 2026: ~520 characters and dots/dashes in the body, so they
+# need an open-ended match instead of the fixed 36 characters the old format had.
+GITHUB_TOKEN_REGEX='(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82}|gh[sou]_[a-zA-Z0-9._-]{36,})'
 
 # Parse arguments
 for arg in "$@"; do
@@ -70,8 +77,12 @@ report_finding() {
     echo "  File: $file:$line_num"
 
     # Aggressive redaction for safe CI output
-    # Remove everything after = or : and sanitize
-    local redacted=$(echo "$preview" | sed 's/[:=].*/:[REDACTED]/' | tr -cd '[:print:]')
+    # Remove everything after = or : and sanitize. A bare token on its own line has
+    # neither, so mask any GitHub token body separately before printing the preview.
+    local redacted=$(echo "$preview" \
+        | sed 's/[:=].*/:[REDACTED]/' \
+        | sed -E 's/(gh[psou]_|github_pat_)[A-Za-z0-9._-]+/\1[REDACTED]/g' \
+        | tr -cd '[:print:]')
     echo "  Preview: ${redacted:0:70}"
     echo ""
 }
@@ -122,6 +133,19 @@ run_self_test() {
     echo 'PASSWORD="MySecretPass123!"' > "$test_dir/test3.conf"
     echo 'SAFE_VAR="${TMDB_API_KEY}"' > "$test_dir/test4.env"
 
+    # Server-side token formats, one per line: the new stateless installation token
+    # (JWT style, ~520 chars), the classic opaque installation token, and a
+    # fine-grained PAT. Prefixes are assembled at runtime so these fixtures do not
+    # make the scanner flag its own source file.
+    local ghs_prefix="gh""s_"
+    local pat_prefix="github""_pat_"
+    local ghs_body=$(printf 'A%.0s' {1..170})
+    {
+        echo "${ghs_prefix}ey${ghs_body}.ey${ghs_body}.sig${ghs_body}"
+        echo "${ghs_prefix}16C7e42F292c6912E7710c838347Ae178B4a"
+        echo "${pat_prefix}11ABCDEFG0$(printf 'b%.0s' {1..72})"
+    } > "$test_dir/test5.txt"
+
     # Test pattern matching
     local test_findings=0
 
@@ -133,11 +157,19 @@ run_self_test() {
         return 1
     fi
 
-    if grep -qE '(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82})' -- "$test_dir/test2.txt"; then
+    if grep -qE "$GITHUB_TOKEN_REGEX" -- "$test_dir/test2.txt"; then
         test_findings=$((test_findings + 1))
         echo -e "${GREEN}✓${NC} Pattern test 2: GitHub token detection works"
     else
         echo -e "${RED}✗${NC} Pattern test 2: FAILED"
+        return 1
+    fi
+
+    if [ "$(grep -cE "$GITHUB_TOKEN_REGEX" -- "$test_dir/test5.txt")" = "3" ]; then
+        test_findings=$((test_findings + 1))
+        echo -e "${GREEN}✓${NC} Pattern test 2b: Stateless, classic and fine-grained token detection works"
+    else
+        echo -e "${RED}✗${NC} Pattern test 2b: FAILED"
         return 1
     fi
 
@@ -211,7 +243,7 @@ PATTERN_NAMES=(
 PATTERN_REGEXES=(
     'TMDB_API_KEY[[:space:]]*[:=][[:space:]]*["\047]?[a-zA-Z0-9]{10,}["\047]?'
     'API_KEY[[:space:]]*[:=][[:space:]]*["\047]?[a-zA-Z0-9]{20,}["\047]?'
-    '(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82})'
+    "$GITHUB_TOKEN_REGEX"
     'AKIA[0-9A-Z]{16}'
     'BEGIN[[:space:]]+(RSA[[:space:]]+)?PRIVATE[[:space:]]+KEY'
     '(PASSWORD|PASS)[[:space:]]*[:=][[:space:]]*["\047][^$\{\}][a-zA-Z0-9!@#$%^&*]{8,}["\047]'


### PR DESCRIPTION
## Was

GitHub App Installation Tokens wechseln auf ein stateless JWT-Format (`ghs_...`, ~520 Zeichen, Punkte im Body, [Changelog](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header)). Der Secret-Scanner kannte nur `ghp_` und `github_pat_` — server-seitige Tokens wurden weder im alten noch im neuen Format erkannt.

```
(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82}|gh[sou]_[a-zA-Z0-9._-]{36,})
```

- ein geteiltes `GITHUB_TOKEN_REGEX` für Self-Test und Haupt-Scan (vorher an zwei Stellen dupliziert)
- `gh[sou]_` deckt Installation-, OAuth- und User-to-Server-Tokens ab, `{36,}` mit Punkten/Bindestrichen trifft klassisches und JWT-Format
- `report_finding()` maskiert jetzt Token-Bodies: die alte Redaktion schnitt nur nach `:` oder `=`, eine nackte Token-Zeile landete mit 70 Zeichen im CI-Log
- Self-Test-Fixtures für alle drei Formate, Präfixe zur Laufzeit zusammengesetzt, damit der Scanner nicht seine eigene Quelle meldet

## Tests

| Gate | Ergebnis |
|---|---|
| `composer test` (phpcs, phpstan, psalm, phpunit) im Docker-Dev-Image | 193/193, 446 Assertions, keine Fehler |
| `secret-scan.sh --self-test` | 3/3 Pattern (neu: 2b für stateless/klassisch/fine-grained) |
| Full-Scan des Repos | 9 Findings, unverändert zur Baseline (bekannte Doku-False-Positives) |
| End-to-End in temporärem Git-Repo | JWT-Format, klassisches `ghs_` (36 Zeichen) und `github_pat_` je als `GITHUB_TOKEN` gemeldet, Preview redigiert zu `ghs_[REDACTED]` |

## Bewusst nicht gefixt

Der adversariale Review (Codex, `gpt-5.4`) hat zwei Punkte gemeldet, die vorbestehende Eigenschaften des Scanners sind und ausserhalb dieses Diffs liegen:

- **Zeilenumbruch-Bypass:** Alle Patterns arbeiten zeilenweise via `grep -nE`. Ein über mehrere Zeilen verteiltes Token entgeht der Erkennung. Betrifft jedes Pattern des Scanners, nicht nur das neue, und würde einen anderen Scan-Ansatz verlangen. Das Werkzeug adressiert versehentliche Commits, nicht bewusste Umgehung.
- **Keine Wortgrenzen im Regex:** `gh[sou]_...` kann als Teilstring matchen. `\b` ist über BSD-grep/busybox nicht portabel, und in einem Secret-Scanner sind False Positives dem Verpassen eines Tokens vorzuziehen. Gleiche Eigenschaft wie bei den bestehenden `ghp_`/`github_pat_`-Patterns.

Gefixt aus dem gleichen Review: die Token-Leak-Stelle in `report_finding()` und die undeklarierte `seq`-Abhängigkeit (jetzt Brace-Expansion, keine externen Tools zusätzlich zu den im Header dokumentierten).

## Hinweise

- `chore(security):` statt `fix:` — der Scanner ist ein Dev/CI-Werkzeug und nicht Teil des Images; ein Release-Bump samt Docker-Publish wäre Rauschen. release-please erzeugt dadurch keinen Version-Bump.
- `docs/security/secret-audit-report.txt` nennt die alte Pattern-Liste, bleibt aber unverändert: datierter Audit-Snapshot vom 22.12.2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)