### PR TITLE
ci: review PRs via direct prompt instead of the code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,31 +3,20 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write, not read: the job posts the review back onto the PR.
+      pull-requests: write
       issues: read
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -36,9 +25,38 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. Pathary is a PHP 8.4 application (Movary
+            fork) using Twig templates, Phinx migrations and a repository layer
+            over PDO. Static analysis (phpcs, phpstan, psalm) and phpunit run in
+            a separate workflow, so do not repeat what those tools already catch.
+
+            Focus on:
+
+            1. Correctness
+               - Logic errors that produce wrong results silently
+               - Unhandled edge cases: null, empty result sets, missing API fields
+               - Error paths that swallow failures
+
+            2. Security
+               - SQL built by string concatenation instead of bound parameters
+               - Unescaped output in Twig (`|raw`) on user-controlled data
+               - Secrets or tokens in code, logs or fixtures
+
+            3. Data safety
+               - Migrations that drop or rewrite columns without a fallback
+               - Writes that can wipe previously synced values with nulls
+
+            4. Tests
+               - Missing regression test for a fixed bug
+               - New branches without a test covering both paths
+
+            Cite file:line for every finding and propose a concrete fix. Report
+            only real problems, no compliments and no summary of what the PR does.
+            If you find nothing worth changing, say so in one line.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Problem

Der `claude-review`-Workflow war nie funktionsfähig, auch nicht als er grün war.

- **Hat nie etwas gepostet:** PRs #76, #77, #78 stammen aus der grünen Phase und haben null `claude`-Kommentare. Entspricht [claude-code-action#1523](https://github.com/anthropics/claude-code-action/issues/1523).
- **Seit 07.07.2026 rot:** bricht mit `result is_error:true` nach einem einzigen Turn und ~2s ab, ohne einen Tool-Call. `total_cost_usd: 0`, kein API-Call.

Nicht durch PR-Inhalte verursacht. Token wurde am 01.08. rotiert, Fehlerbild unverändert. Die Workflow-Datei ist seit 12.01.2026 unverändert, `anthropics/claude-code-action@v1` hat seit dem letzten grünen Lauf 30 Commits bekommen.

## Ursachen

**1. Plugin-Slash-Command-Pfad.** Die Kombination `plugins: code-review@claude-code-plugins` plus `prompt: '/code-review:code-review ...'` hat mehrere offene Upstream-Regressionen:

- [#1458](https://github.com/anthropics/claude-code-action/issues/1458) — "plugin skill invocation via prompt fails after SHA fad22eb", exakt unser Aufrufmuster
- [#1145](https://github.com/anthropics/claude-code-action/issues/1145) — "Skill tool fails immediately when invoking code-review plugin"
- [#880](https://github.com/anthropics/claude-code-action/issues/880) — erklärt, warum die Fehlermeldung im Log nie sichtbar wird

Das offizielle Beispiel `examples/pr-review-comprehensive.yml` der Action nutzt stattdessen einen direkten `prompt` ohne Plugin.

**2. Fehlende Schreibrechte.** `permissions` hatte `pull-requests: read`. Der Job hätte ein Review gar nicht posten können, auch wenn er eines erzeugt hätte. Das offizielle Beispiel nutzt `write`.

## Änderung

- Plugin und Marketplace raus, direkter `prompt` mit `REPO`/`PR NUMBER` nach offiziellem Muster
- `pull-requests: write`
- `track_progress: true`
- `actions/checkout@v4` → `@v6` (v4 zielt auf das abgekündigte Node 20, erzeugt eine Warnung in jedem Lauf)
- Review-Anweisungen auf diese Codebase zugeschnitten (PHP 8.4, Twig, Phinx, PDO-Repositories) und explizit abgegrenzt gegen das, was phpcs, phpstan, psalm und phpunit ohnehin abdecken

## Verifikation

**Der eigene `claude-review`-Check dieses PRs wird übersprungen, das ist erwartet.** `claude-code-action` verweigert die Ausführung, sobald die Workflow-Datei vom Default-Branch abweicht:

```
Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version
on the repository's default branch.
```

Ein Workflow-Fix lässt sich deshalb prinzipbedingt nicht im eigenen PR testen. Die echte Prüfung ist der nächste PR nach dem Merge: dort muss der Job entweder ein Review-Kommentar posten oder mit einer sichtbaren Meldung scheitern statt still zu sterben.

YAML-Syntax lokal validiert. Der Workflow lässt sich nicht lokal ausführen (`pull_request`-Trigger, Secret nur in Actions verfügbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)